### PR TITLE
WIP Performance improvements when working on individual files

### DIFF
--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -43,6 +43,8 @@ module CodeOwnership
     Private.file_annotations_mapper.remove_file_annotation!(filename)
   end
 
+  VALIDATE_ALL_OBJECTS = Object.new.freeze
+
   sig do
     params(
       files: T::Array[String],
@@ -51,11 +53,17 @@ module CodeOwnership
     ).void
   end
   def validate!(
-    files: Private.tracked_files,
+    files: VALIDATE_ALL_OBJECTS,
     autocorrect: true,
     stage_changes: true
   )
-    tracked_file_subset = Private.tracked_files & files
+    tracked_file_subset = if files == VALIDATE_ALL_OBJECTS
+      Private.tracked_files
+    else
+      files.select do |file|
+        Private.tracked_file?(file)
+      end
+    end
     Private.validate!(files: tracked_file_subset, autocorrect: autocorrect, stage_changes: stage_changes)
   end
 

--- a/lib/code_ownership/private.rb
+++ b/lib/code_ownership/private.rb
@@ -92,6 +92,12 @@ module CodeOwnership
       @tracked_files ||= Dir.glob(configuration.owned_globs)
     end
 
+    def self.tracked_file?(file)
+      configuration.owned_globs.any? do |glob|
+        File.fnmatch(glob, file)
+      end
+    end
+
     sig { params(team_name: String, location_of_reference: String).returns(CodeTeams::Team) }
     def self.find_team!(team_name, location_of_reference)
       found_team = CodeTeams.find(team_name)

--- a/lib/code_ownership/private/validations/github_codeowners_up_to_date.rb
+++ b/lib/code_ownership/private/validations/github_codeowners_up_to_date.rb
@@ -106,6 +106,7 @@ module CodeOwnership
           end
 
           Private.mappers.flat_map do |mapper|
+            # FIXME this triggers tracked_file glob
             codeowners_lines = mapper.codeowners_lines_to_owners.filter_map do |line, team|
               team_mapping = github_team_map[team&.name]
               next unless team_mapping


### PR DESCRIPTION
While doing local development and using this as a pre-commit hook, it can take 8 seconds even for single files. I used `rbspy` to capture a flamegraph, and saw that it's building doing a glob of the entire repository just to get a list of files it can work on during the CLI. That is`Private.tracked_files`.

This is a WIP, but so far:

When working on a given list of files, avoid triggering the Dir.glob which can add 2 seconds. This adds a `tracked_file?`method which uses `File.fnmatch?` which can check against the globs to see if a filename matches rather than loading all the files

Note: this doesn't improve performance yet, as something else is also triggering `Private.tracked_file`. I had a thought of using a cache to track file ownership, but hadn't experimented yet.