### PR TITLE
Use ParsePackwerk function for package owner implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_ownership (1.28.1)
+    code_ownership (1.28.2)
       code_teams (~> 1.0)
       parse_packwerk
       sorbet-runtime

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "code_ownership"
-  spec.version       = '1.28.1'
+  spec.version       = '1.28.2'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -103,6 +103,11 @@ RSpec.describe CodeOwnership do
             metadata:
               owner: Bar
           CONTENTS
+
+          write_file('package.yml', <<~CONTENTS)
+            enforce_dependency: true
+            enforce_privacy: true
+          CONTENTS
         end
 
         it 'lets the user know that each file can only have ownership defined in one way' do
@@ -757,7 +762,7 @@ RSpec.describe CodeOwnership do
     before { create_non_empty_application }
 
     it 'returns the right team' do
-      team = CodeOwnership.for_package(ParsePackwerk.all.last)
+      team = CodeOwnership.for_package(ParsePackwerk.find('packs/my_other_package'))
       expect(team.name).to eq 'Bar'
     end
   end
@@ -802,6 +807,11 @@ RSpec.describe CodeOwnership do
 
           # Some content
         CONTENTS
+
+        write_file('package.yml', <<~CONTENTS)
+          enforce_dependency: true
+          enforce_privacy: true
+        CONTENTS
       end
 
       it 'removes the annotation' do
@@ -833,6 +843,11 @@ RSpec.describe CodeOwnership do
           // @team Foo
 
           // Some content
+        CONTENTS
+
+        write_file('package.yml', <<~CONTENTS)
+          enforce_dependency: true
+          enforce_privacy: true
         CONTENTS
       end
 

--- a/spec/support/application_fixtures.rb
+++ b/spec/support/application_fixtures.rb
@@ -42,6 +42,11 @@ RSpec.shared_context 'application fixtures' do
         owner: Bar
     CONTENTS
 
+    write_file('package.yml', <<~CONTENTS)
+      enforce_dependency: true
+      enforce_privacy: true
+    CONTENTS
+
     write_file('packs/my_other_package/my_file.rb')
   end
 


### PR DESCRIPTION
I was looking into whether nested packs would break package ownership. I realized that our old implementation of getting the owner of one file used a trie. I think this *would* work for nested packs, because it would find the nearest pack. However, I was worried things might start to fail when a file is a child of a parent pack and a child pack.

I think in practice, a parent pack probably should not be owned until all of the children packs are owned by the same team -- I **think** that's probably the only thing that makes sense. We could look into fixing this.

In the meantime, I found that our old implementation was convoluted, and actually slower than an implementation we had in `ParsePackwerk`.

# Script
```ruby
require 'code_ownership'
require 'benchmark'
all_files = Dir['packs/**/*.rb'];
all_files.count # 32601
total_time = Benchmark.measure { all_files.each { |f| CodeOwnership.for_file(f) } }.real # 8.699477000162005
puts "Total time is: #{total_time}, or #{total_time / all_files.count.to_f} seconds per file"
```

# Before
`Total time is: 8.699477000162005, or 0.00026684693721548436 seconds per file`

# After
`Total time is: 7.134068000130355, or 0.0002188297291534111 seconds per file`
