### PR TITLE
Check for file annotation on more than just the first line

### DIFF
--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -53,6 +53,43 @@ RSpec.describe CodeOwnership::Cli do
           MSG
           subject
         end
+
+        context 'when file is annotated' do
+          let(:argv) { ['for_file', 'app/services/my_service.rb'] }
+
+          before do
+            write_file('app/services/my_service.rb', <<~RUBY)
+            # @team My Other Team
+            RUBY
+            write_file('config/teams/my_other_team.yml', <<~YML)
+              name: My Other Team
+            YML
+          end
+
+          it 'outputs the team info in human readable format' do
+            expect(CodeOwnership::Cli).to receive(:puts).with(<<~MSG)
+              Team: My Other Team
+              Team YML: config/teams/my_other_team.yml
+            MSG
+            subject
+          end
+
+          context 'when annotation is not on the first line' do
+            before do
+              write_file('app/services/my_service.rb', <<~RUBY)
+              # frozen_string_literal: true
+              # @team My Other Team
+              RUBY
+            end
+            it 'outputs the team info in human readable format' do
+              expect(CodeOwnership::Cli).to receive(:puts).with(<<~MSG)
+                Team: My Other Team
+                Team YML: config/teams/my_other_team.yml
+              MSG
+              subject
+            end
+          end
+        end
       end
 
       context 'when run with no files' do


### PR DESCRIPTION
Fixes: https://github.com/rubyatscale/code_ownership/issues/21

Check every line at the beginning of the file starting with a '#' for the @team annotation.

The current version of `code_ownership` does now allow for [Ruby "magic" comments](https://docs.ruby-lang.org/en/3.1/syntax/comments_rdoc.html#label-Magic+Comments), like `# frozen_string_literal: true` which should be on the very first line of a Ruby file, and `code_ownership` also wants its annotation to exist on that first line. 

To fix that, I updated the file annotation checker to start at the top of the Ruby file, and for each line starting with a `#`, we check it for the team annotation. As soon as a line does not begin with `#`, we stop checking for the annotation.


This is now allowed:

```ruby
# frozen_string_literal: true
# @team My Team

class Blah
end
```

This is also allowed:

```ruby
# Some other comment
# another comment goes here
# @team My Team

class Blah
end
```
