### PR TITLE
Create bin/codeownership for_team for code ownership reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ Under the hood, this finds the file where the class is defined and returns the o
 
 See `code_ownership_spec.rb` for an example.
 
+### `for_team`
+`CodeOwnership.for_team` can be used to generate an ownership report for a team.
+```ruby
+CodeOwnership.for_team('My Team')
+```
+
+You can shovel this into a markdown file for easy viewing using the CLI:
+```
+bin/codeownership for_team 'My Team' > tmp/ownership_report.md
+```
+
 ## Usage: Generating a `CODEOWNERS` file
 
 A `CODEOWNERS` file defines who owns specific files or paths in a repository. When you run `bin/codeownership validate`, a `.github/CODEOWNERS` file will automatically be generated and updated.

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -11,6 +11,8 @@ module CodeOwnership
         validate!(argv)
       elsif command == 'for_file'
         for_file(argv)
+      elsif command == 'for_team'
+        for_team(argv)
       elsif [nil, "help"].include?(command)
         puts <<~USAGE
           Usage: bin/codeownership <subcommand>
@@ -18,6 +20,7 @@ module CodeOwnership
           Subcommands:
             validate - run all validations
             for_file - find code ownership for a single file
+            for_team - find code ownership information for a team
             help  - display help information about code_ownership
         USAGE
       else
@@ -114,6 +117,28 @@ module CodeOwnership
           Team YML: #{team_yml}
         MSG
       end
+    end
+
+    def self.for_team(argv)
+      options = {}
+
+      parser = OptionParser.new do |opts|
+        opts.banner = 'Usage: bin/codeownership for_team \'Team Name\''
+
+        opts.on('--help', 'Shows this prompt') do
+          puts opts
+          exit
+        end
+      end
+      teams = argv.select { |arg| !arg.start_with?('--') }
+      args = parser.order!(argv) {}
+      parser.parse!(args)
+
+      if teams.count != 1
+        raise "Please pass in one team. Use `bin/codeownership for_team --help` for more info"
+      end
+      
+      puts CodeOwnership.for_team(teams.first)
     end
 
     private_class_method :validate!

--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe CodeOwnership::Cli do
       Subcommands:
         validate - run all validations
         for_file - find code ownership for a single file
+        for_team - find code ownership information for a team
         help  - display help information about code_ownership
       EXPECTED
       expect(CodeOwnership::Cli).to receive(:puts).with(expected)

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -911,4 +911,57 @@ RSpec.describe CodeOwnership do
       end
     end
   end
+
+  describe '.for_team' do
+    before { create_non_empty_application }
+
+    it 'prints out ownership information for the given team' do
+      expect(CodeOwnership.for_team('Bar')).to eq <<~OWNERSHIP
+        # Code Ownership Report for `Bar` Team
+        ## Annotations at the top of file
+        - frontend/javascripts/packages/my_package/owned_file.jsx
+        - packs/my_pack/owned_file.rb
+
+        ## Team-specific owned globs
+        - app/services/bar_stuff/**
+        - frontend/javascripts/bar_stuff/**
+
+        ## Owner metadata key in package.yml
+        - packs/my_other_package/**/**
+
+        ## Owner metadata key in package.json
+        - frontend/javascripts/packages/my_other_package/**/**
+      OWNERSHIP
+    end
+
+    context 'team does not own any packs or files using annotations' do
+      before do
+        write_file('config/teams/foo.yml', <<~CONTENTS)
+          name: Foo
+          github:
+            team: '@MyOrg/foo-team'
+          owned_globs:
+            - app/services/foo_stuff/**
+        CONTENTS
+      end
+
+   it 'prints out ownership information for the given team' do
+      expect(CodeOwnership.for_team('Foo')).to eq <<~OWNERSHIP
+        # Code Ownership Report for `Foo` Team
+        ## Annotations at the top of file
+        This team owns nothing in this category.
+
+        ## Team-specific owned globs
+        - app/services/foo_stuff/**
+
+        ## Owner metadata key in package.yml
+        This team owns nothing in this category.
+
+        ## Owner metadata key in package.json
+        This team owns nothing in this category.
+      OWNERSHIP
+    end
+    end
+  end
+
 end


### PR DESCRIPTION
This was inspired by some rake tasks we had within the Gusto monolith to get ownership reports for a team.

This seems like a valuable thing to upstream.

Right now, this is a simple report that just goes through each "mapper" type and prints out ownership based on codeowners line. Reusing the codeowners interface felt reasonable here.

This prints the information out as a simple markdown for easy viewing.

Example in Gusto's codebase: https://github.com/Gusto/zenpayroll/pull/160107