### PR TITLE
Require FileUtils explicitly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_ownership (1.29.0)
+    code_ownership (1.29.1)
       code_teams (~> 1.0)
       parse_packwerk
       sorbet-runtime

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "code_ownership"
-  spec.version       = '1.29.0'
+  spec.version       = '1.29.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -2,6 +2,7 @@
 
 require 'optparse'
 require 'pathname'
+require 'fileutils'
 
 module CodeOwnership
   class Cli


### PR DESCRIPTION
Something in our test suite was requiring this, but this causes a failure when using in an application that doesn't explicitly require `fileutils` somewhere.
