### PR TITLE
Introduce `CodeOwnership#first_owned_file_for_backtrace`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_ownership (1.29.2)
+    code_ownership (1.29.3)
       code_teams (~> 1.0)
       packs
       sorbet-runtime
@@ -15,7 +15,7 @@ GEM
     coderay (1.1.3)
     diff-lcs (1.4.4)
     method_source (1.0.0)
-    packs (0.0.5)
+    packs (0.0.6)
       sorbet-runtime
     parser (3.1.2.0)
       ast (~> 2.4.1)

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "code_ownership"
-  spec.version       = '1.29.2'
+  spec.version       = '1.29.3'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -58,7 +58,6 @@ module CodeOwnership
         ownership_information += ownership_for_mapper
       end
 
-      
       ownership_information << ""
     end
 
@@ -93,11 +92,14 @@ module CodeOwnership
   # first line that corresponds to a file with assigned ownership
   sig { params(backtrace: T.nilable(T::Array[String]), excluded_teams: T::Array[::CodeTeams::Team]).returns(T.nilable(::CodeTeams::Team)) }
   def for_backtrace(backtrace, excluded_teams: [])
-    return unless backtrace
+    first_owned_file_for_backtrace(backtrace, excluded_teams: excluded_teams)&.first
+  end
 
+  sig { params(backtrace: T.nilable(T::Array[String]), excluded_teams: T::Array[::CodeTeams::Team]).returns(T.nilable([::CodeTeams::Team, String])) }
+  def first_owned_file_for_backtrace(backtrace, excluded_teams: [])
     backtrace_with_ownership(backtrace).find do |(team, _file)|
       team && !excluded_teams.include?(team)
-    end&.first
+    end
   end
 
   sig { params(backtrace: T.nilable(T::Array[String])).returns(T::Array[[T.nilable(::CodeTeams::Team), String]]) }
@@ -129,6 +131,7 @@ module CodeOwnership
       ]
     end
   end
+  private_class_method(:backtrace_with_ownership)
 
   sig { params(klass: T.nilable(T.any(Class, Module))).returns(T.nilable(::CodeTeams::Team)) }
   def for_class(klass)

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -108,7 +108,7 @@ module CodeOwnership
     nil
   end
 
-  sig { params(backtrace: T.nilable(T::Array[String])).returns(T::Array[[T.nilable(::CodeTeams::Team), String]]) }
+  sig { params(backtrace: T.nilable(T::Array[String])).returns(T::Enumerable[[T.nilable(::CodeTeams::Team), String]]) }
   def backtrace_with_ownership(backtrace)
     return [] unless backtrace
 
@@ -127,7 +127,7 @@ module CodeOwnership
         `(?<function>.*)' # Matches "`block (3 levels) in create'"
       \z}x
 
-    backtrace.filter_map do |line|
+    backtrace.lazy.filter_map do |line|
       match = line.match(backtrace_line)
       next unless match
 

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -705,22 +705,13 @@ RSpec.describe CodeOwnership do
   end
 
   describe '.for_backtrace' do
-    def prevent_false_positive!
-      # The above code should raise, and we should never arrive at this next expectation.
-      # This is just to protect against a case where we have a false-postive test because the above does not raise.
-      expect(true).to eq false # rubocop:disable RSpec/ExpectActual
-    end
-
     before do
       create_files_with_defined_classe
     end
 
     context 'excluded_teams is not passed in as an input parameter' do
       it 'finds the right team' do
-        begin # rubocop:disable Style/RedundantBegin
-          MyFile.raise_error
-          prevent_false_positive!
-        rescue StandardError => ex
+        expect { MyFile.raise_error }.to raise_error do |ex|
           expect(CodeOwnership.for_backtrace(ex.backtrace)).to eq CodeTeams.find('Bar')
         end
       end
@@ -728,10 +719,7 @@ RSpec.describe CodeOwnership do
 
     context 'excluded_teams is passed in as an input parameter' do
       it 'ignores the first part of the stack trace and finds the next viable owner' do
-        begin # rubocop:disable Style/RedundantBegin
-          MyFile.raise_error
-          prevent_false_positive!
-        rescue StandardError => ex
+        expect { MyFile.raise_error }.to raise_error do |ex|
           team_to_exclude = CodeTeams.find('Bar')
           expect(CodeOwnership.for_backtrace(ex.backtrace, excluded_teams: [team_to_exclude])).to eq CodeTeams.find('Foo')
         end

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -749,6 +749,14 @@ RSpec.describe CodeOwnership do
         end
       end
     end
+
+    context 'when nothing is owned' do
+      it 'returns nil' do
+        expect { raise 'opsy' }.to raise_error do |ex|
+          expect(CodeOwnership.first_owned_file_for_backtrace(ex.backtrace)).to be_nil
+        end
+      end
+    end
   end
 
   describe '.for_class' do

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -727,19 +727,25 @@ RSpec.describe CodeOwnership do
     end
   end
 
-  describe '.backtrace_with_ownership' do
+  describe '.first_owned_file_for_backtrace' do
     before do
       create_files_with_defined_classe
+    end
+
+
+    context 'excluded_teams is not passed in as an input parameter' do
+      it 'finds the right team' do
+        expect { MyFile.raise_error }.to raise_error do |ex|
+          expect(CodeOwnership.first_owned_file_for_backtrace(ex.backtrace)).to eq [CodeTeams.find('Bar'), 'app/my_error.rb']
+        end
+      end
     end
 
     context 'excluded_teams is not passed in as an input parameter' do
       it 'finds the right team' do
         expect { MyFile.raise_error }.to raise_error do |ex|
-          expect(CodeOwnership.backtrace_with_ownership(ex.backtrace).first(3)).to match([
-            [CodeTeams.find('Bar'), 'app/my_error.rb'],
-            [CodeTeams.find('Foo'), 'app/my_file.rb'],
-            [nil, include('lib/code_ownership_spec.rb')]
-          ])
+          team_to_exclude = CodeTeams.find('Bar')
+          expect(CodeOwnership.first_owned_file_for_backtrace(ex.backtrace, excluded_teams: [team_to_exclude])).to eq [CodeTeams.find('Foo'), 'app/my_file.rb']
         end
       end
     end

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -727,6 +727,24 @@ RSpec.describe CodeOwnership do
     end
   end
 
+  describe '.backtrace_with_ownership' do
+    before do
+      create_files_with_defined_classe
+    end
+
+    context 'excluded_teams is not passed in as an input parameter' do
+      it 'finds the right team' do
+        expect { MyFile.raise_error }.to raise_error do |ex|
+          expect(CodeOwnership.backtrace_with_ownership(ex.backtrace).first(3)).to match([
+            [CodeTeams.find('Bar'), 'app/my_error.rb'],
+            [CodeTeams.find('Foo'), 'app/my_file.rb'],
+            [nil, include('lib/code_ownership_spec.rb')]
+          ])
+        end
+      end
+    end
+  end
+
   describe '.for_class' do
     before { create_files_with_defined_classe }
 


### PR DESCRIPTION
The intent is to expose more data and enable a consumer to report additional information. For example, we wish to use this method to log the "blamed" stack of an error.