### PR TITLE
Fix bug where team YML files are considered unowned

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_ownership (1.30.0)
+    code_ownership (1.31.0)
       code_teams (~> 1.0)
       packs
       sorbet-runtime

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "code_ownership"
-  spec.version       = '1.30.0'
+  spec.version       = '1.31.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership/private.rb
+++ b/lib/code_ownership/private.rb
@@ -16,6 +16,7 @@ require 'code_ownership/private/ownership_mappers/file_annotations'
 require 'code_ownership/private/ownership_mappers/team_globs'
 require 'code_ownership/private/ownership_mappers/package_ownership'
 require 'code_ownership/private/ownership_mappers/js_package_ownership'
+require 'code_ownership/private/ownership_mappers/team_yml_ownership'
 
 module CodeOwnership
   module Private
@@ -64,6 +65,7 @@ module CodeOwnership
         Private::OwnershipMappers::TeamGlobs.new,
         Private::OwnershipMappers::PackageOwnership.new,
         Private::OwnershipMappers::JsPackageOwnership.new,
+        Private::OwnershipMappers::TeamYmlOwnership.new,
       ]
     end
 

--- a/lib/code_ownership/private/ownership_mappers/team_yml_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/team_yml_ownership.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# typed: true
+
+module CodeOwnership
+  module Private
+    module OwnershipMappers
+      class TeamYmlOwnership
+        extend T::Sig
+        include Interface
+
+        @@map_files_to_owners = T.let(@map_files_to_owners, T.nilable(T::Hash[String, T.nilable(::CodeTeams::Team)])) # rubocop:disable Style/ClassVars
+        @@map_files_to_owners = {} # rubocop:disable Style/ClassVars
+        @@codeowners_lines_to_owners = T.let(@codeowners_lines_to_owners, T.nilable(T::Hash[String, T.nilable(::CodeTeams::Team)])) # rubocop:disable Style/ClassVars
+        @@codeowners_lines_to_owners = {} # rubocop:disable Style/ClassVars
+
+        sig do
+          override.
+            params(files: T::Array[String]).
+            returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+        end
+        def map_files_to_owners(files) # rubocop:disable Lint/UnusedMethodArgument
+          return @@map_files_to_owners if @@map_files_to_owners&.keys && @@map_files_to_owners.keys.count > 0
+
+          @@map_files_to_owners = CodeTeams.all.each_with_object({}) do |team, map| # rubocop:disable Style/ClassVars
+            map[team.config_yml] = team
+          end
+        end
+
+        sig do
+          override.params(file: String).
+            returns(T.nilable(::CodeTeams::Team))
+        end
+        def map_file_to_owner(file)
+          map_files_to_owners([file])[file]
+        end
+
+        sig do
+          override.returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+        end
+        def codeowners_lines_to_owners
+          return @@codeowners_lines_to_owners if @@codeowners_lines_to_owners&.keys && @@codeowners_lines_to_owners.keys.count > 0
+
+          @@codeowners_lines_to_owners = CodeTeams.all.each_with_object({}) do |team, map| # rubocop:disable Style/ClassVars
+            map[team.config_yml] = team
+          end
+        end
+
+        sig { override.void }
+        def bust_caches!
+          @@codeowners_lines_to_owners = {} # rubocop:disable Style/ClassVars
+          @@map_files_to_owners = {} # rubocop:disable Style/ClassVars
+        end
+
+        sig { override.returns(String) }
+        def description
+          'Team YML ownership'
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -736,6 +736,10 @@ RSpec.describe CodeOwnership do
       expect(CodeOwnership.for_file('frontend/javascripts/packages/my_other_package/my_file.jsx')).to eq CodeTeams.find('Bar')
     end
 
+    it 'maps a team YML to be owned by the team itself' do
+      expect(CodeOwnership.for_file('config/teams/bar.yml')).to eq CodeTeams.find('Bar')
+    end
+
     describe 'path formatting expectations' do
       # All file paths must be clean paths relative to the root: https://apidock.com/ruby/Pathname/cleanpath
       it 'will not find the ownership of a file that is not a cleanpath' do

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -189,6 +189,9 @@ RSpec.describe CodeOwnership do
 
               # Owner metadata key in package.json
               /frontend/javascripts/packages/my_other_package/**/** @MyOrg/bar-team
+
+              # Team YML ownership
+              /config/teams/bar.yml @MyOrg/bar-team
             EXPECTED
           end
 
@@ -220,6 +223,9 @@ RSpec.describe CodeOwnership do
 
                 # Owner metadata key in package.json
                 /frontend/javascripts/packages/my_other_package/**/** @MyOrg/bar-team
+
+                # Team YML ownership
+                /config/teams/bar.yml @MyOrg/bar-team
               EXPECTED
             end
           end
@@ -428,6 +434,9 @@ RSpec.describe CodeOwnership do
 
               # Owner metadata key in package.json
               /frontend/javascripts/packages/my_other_package/**/** @MyOrg/bar-team
+
+              # Team YML ownership
+              /config/teams/bar.yml @MyOrg/bar-team
             CODEOWNERS
 
             expect_any_instance_of(codeowners_validation).to_not receive(:`) # rubocop:disable RSpec/AnyInstance
@@ -486,6 +495,8 @@ RSpec.describe CodeOwnership do
               # Owner metadata key in package.json
               /frontend/javascripts/packages/my_other_package/**/** @MyOrg/bar-team
 
+              # Team YML ownership
+              /config/teams/bar.yml @MyOrg/bar-team
             CODEOWNERS
 
             expect_any_instance_of(codeowners_validation).to_not receive(:`) # rubocop:disable RSpec/AnyInstance
@@ -530,6 +541,8 @@ RSpec.describe CodeOwnership do
               # Owner metadata key in package.json
               /frontend/javascripts/packages/my_other_package/**/** @MyOrg/bar-team
 
+              # Team YML ownership
+              /config/teams/bar.yml @MyOrg/bar-team
             CODEOWNERS
 
             expect_any_instance_of(codeowners_validation).to_not receive(:`) # rubocop:disable RSpec/AnyInstance
@@ -1000,6 +1013,9 @@ RSpec.describe CodeOwnership do
 
         ## Owner metadata key in package.json
         - frontend/javascripts/packages/my_other_package/**/**
+
+        ## Team YML ownership
+        - config/teams/bar.yml
       OWNERSHIP
     end
 
@@ -1028,6 +1044,9 @@ RSpec.describe CodeOwnership do
 
         ## Owner metadata key in package.json
         This team owns nothing in this category.
+
+        ## Team YML ownership
+        - config/teams/foo.yml
       OWNERSHIP
     end
     end


### PR DESCRIPTION
I realized teams were not getting tagged when their team YML files were updated. Teams should be owning their own configuration, especially since that configuration itself contains ownership information, which teams should be aware of when it is changed.

This PR fixes this bug by adding a new mapper that explicitly marks team YML files as being owned by teams.
