### PR TITLE
Load configuration before calling public APIs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_ownership (1.32.0)
+    code_ownership (1.32.1)
       code_teams (~> 1.0)
       packs
       sorbet-runtime

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "code_ownership"
-  spec.version       = '1.32.0'
+  spec.version       = '1.32.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -28,6 +28,8 @@ module CodeOwnership
     return nil if file.start_with?('./')
     return @for_file[file] if @for_file.key?(file)
 
+    Private.load_configuration!
+
     owner = T.let(nil, T.nilable(CodeTeams::Team))
 
     Mapper.all.each do |mapper|
@@ -40,6 +42,8 @@ module CodeOwnership
 
   sig { params(team: T.any(CodeTeams::Team, String)).returns(String) }
   def for_team(team)
+    Private.load_configuration!
+
     team = T.must(CodeTeams.find(team)) if team.is_a?(String)
     ownership_information = T.let([], T::Array[String])
 
@@ -87,6 +91,7 @@ module CodeOwnership
     autocorrect: true,
     stage_changes: true
   )
+    Private.load_configuration!
     tracked_file_subset = Private.tracked_files & files
     Private.validate!(files: tracked_file_subset, autocorrect: autocorrect, stage_changes: stage_changes)
   end

--- a/lib/code_ownership/private.rb
+++ b/lib/code_ownership/private.rb
@@ -25,6 +25,14 @@ module CodeOwnership
       @configuration ||= Configuration.fetch
     end
 
+    # This is just an alias for `configuration` that makes it more explicit what we're doing instead of just calling `configuration`.
+    # This is necessary because configuration may contain extensions of code ownership, so those extensions should be loaded prior to
+    # calling APIs that provide ownership information.
+    sig { returns(Configuration) }
+    def self.load_configuration!
+      configuration
+    end
+
     sig { void }
     def self.bust_caches!
       @configuration = nil

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CodeOwnership do
 
   describe '.for_backtrace' do
     before do
-      create_files_with_defined_classe
+      create_files_with_defined_classes
     end
 
     context 'excluded_teams is not passed in as an input parameter' do
@@ -111,7 +111,7 @@ RSpec.describe CodeOwnership do
   describe '.first_owned_file_for_backtrace' do
     before do
       create_minimal_configuration
-      create_files_with_defined_classe
+      create_files_with_defined_classes
     end
 
 
@@ -142,7 +142,9 @@ RSpec.describe CodeOwnership do
   end
 
   describe '.for_class' do
-    before { create_files_with_defined_classe }
+    before do
+      create_files_with_defined_classes
+    end
 
     it 'can find the right owner for a class' do
       expect(CodeOwnership.for_class(MyFile)).to eq CodeTeams.find('Foo')

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe CodeOwnership do
   describe '.for_backtrace' do
     before do
       create_files_with_defined_classes
+      create_minimal_configuration
     end
 
     context 'excluded_teams is not passed in as an input parameter' do
@@ -144,6 +145,7 @@ RSpec.describe CodeOwnership do
   describe '.for_class' do
     before do
       create_files_with_defined_classes
+      create_minimal_configuration
     end
 
     it 'can find the right owner for a class' do

--- a/spec/support/application_fixtures.rb
+++ b/spec/support/application_fixtures.rb
@@ -63,7 +63,7 @@ RSpec.shared_context 'application fixtures' do
   end
 
 
-  let(:create_files_with_defined_classe) do
+  let(:create_files_with_defined_classes) do
     write_file('app/my_file.rb', <<~CONTENTS)
       # @team Foo
 


### PR DESCRIPTION
Now that an extension can add new mappers, we want to load the configuration explicitly before calling public APIs.
