### PR TITLE
Reduce calls to Object#const_source_location

### DIFF
--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -159,9 +159,8 @@ module CodeOwnership
     # We use key because the memoized value could be `nil`
     if !@memoized_values.key?(klass_string)
       path = Private.path_from_klass_string(klass_string)
-      return nil if path.nil?
 
-      value_to_memoize = for_file(path)
+      value_to_memoize = path ? for_file(path) : nil
       @memoized_values[klass_string] = value_to_memoize
       value_to_memoize
     else

--- a/lib/code_ownership/private.rb
+++ b/lib/code_ownership/private.rb
@@ -60,12 +60,10 @@ module CodeOwnership
     # or nil if it can't find something
     sig { params(klass_string: T.nilable(String)).returns(T.nilable(String)) }
     def self.path_from_klass_string(klass_string)
-      if klass_string
-        path = Object.const_source_location(klass_string)&.first
-        (path && Pathname.new(path).relative_path_from(Pathname.pwd).to_s) || nil
-      else
-        nil
-      end
+      return nil if klass_string.nil? || klass_string == ""
+
+      path = Object.const_source_location(klass_string)&.first
+      path && Pathname.new(path).relative_path_from(Pathname.pwd).to_s
     end
 
     #


### PR DESCRIPTION
Prior to this change, a constant which did not exist would take an expensive path through `Object.const_source_location` every time. Now, we cache that nil result.

1. Constants which do not exist are cached
2. Blank class strings short-circuit to nil, previously they would raise a NameError
3. Remove unnecessary `|| nil` 

Maybe this change is not possible if constants are not eager loaded? 🤔 