### PR TITLE
Use Codeowners file as incremental cache during validations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_ownership (1.32.7)
+    code_ownership (1.32.8)
       code_teams (~> 1.0)
       packs
       sorbet-runtime

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "code_ownership"
-  spec.version       = '1.32.7'
+  spec.version       = '1.32.8'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -19,6 +19,7 @@ module CodeOwnership
   extend T::Helpers
 
   requires_ancestor { Kernel }
+  GlobsToOwningTeamMap = T.type_alias { T::Hash[String, CodeTeams::Team] }
 
   sig { params(file: String).returns(T.nilable(CodeTeams::Team)) }
   def for_file(file)

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -51,7 +51,7 @@ module CodeOwnership
     ownership_information << "# Code Ownership Report for `#{team.name}` Team"
     Mapper.all.each do |mapper|
       ownership_information << "## #{mapper.description}"
-      codeowners_lines = mapper.codeowners_lines_to_owners
+      codeowners_lines = mapper.globs_to_owner(Private.tracked_files)
       ownership_for_mapper = []
       codeowners_lines.each do |line, team_for_line|
         next if team_for_line.nil?

--- a/lib/code_ownership/mapper.rb
+++ b/lib/code_ownership/mapper.rb
@@ -51,6 +51,15 @@ module CodeOwnership
     def codeowners_lines_to_owners
     end
 
+    #
+    # This should be fast when run with MANY files
+    #
+    sig do
+      abstract.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
+    end
+    def update_cache(cache, files)
+    end
+
     sig { abstract.returns(String) }
     def description
     end

--- a/lib/code_ownership/mapper.rb
+++ b/lib/code_ownership/mapper.rb
@@ -40,15 +40,9 @@ module CodeOwnership
     #
     sig do
       abstract.params(files: T::Array[String]).
-        returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+        returns(T::Hash[String, ::CodeTeams::Team])
     end
-    def map_files_to_owners(files)
-    end
-
-    sig do
-      abstract.returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
-    end
-    def codeowners_lines_to_owners
+    def globs_to_owner(files)
     end
 
     #
@@ -73,7 +67,7 @@ module CodeOwnership
       glob_to_owner_map_by_mapper_description = {}
 
       Mapper.all.each do |mapper|
-        mapped_files = mapper.codeowners_lines_to_owners
+        mapped_files = mapper.globs_to_owner(Private.tracked_files)
         mapped_files.each do |glob, owner|
           next if owner.nil?
           glob_to_owner_map_by_mapper_description[mapper.description] ||= {}

--- a/lib/code_ownership/private.rb
+++ b/lib/code_ownership/private.rb
@@ -44,6 +44,8 @@ module CodeOwnership
 
     sig { params(files: T::Array[String], autocorrect: T::Boolean, stage_changes: T::Boolean).void }
     def self.validate!(files:, autocorrect: true, stage_changes: true)
+      CodeownersFile.update_cache!(files) if CodeownersFile.use_codeowners_cache?
+
       errors = Validator.all.flat_map do |validator|
         validator.validation_errors(
           files: files,
@@ -92,7 +94,13 @@ module CodeOwnership
     sig { returns(GlobCache) }
     def self.glob_cache
       @glob_cache ||= T.let(@glob_cache, T.nilable(GlobCache))
-      @glob_cache ||= Mapper.to_glob_cache
+      @glob_cache ||= begin
+        if CodeownersFile.use_codeowners_cache?
+          CodeownersFile.to_glob_cache
+        else
+          Mapper.to_glob_cache
+        end
+      end
     end
   end
 

--- a/lib/code_ownership/private/glob_cache.rb
+++ b/lib/code_ownership/private/glob_cache.rb
@@ -7,12 +7,11 @@ module CodeOwnership
       extend T::Sig
 
       MapperDescription = T.type_alias { String }
-      GlobsByMapper = T.type_alias { T::Hash[String, CodeTeams::Team] }
 
       CacheShape = T.type_alias do
         T::Hash[
           MapperDescription,
-          GlobsByMapper
+          GlobsToOwningTeamMap
         ]
       end
 

--- a/lib/code_ownership/private/ownership_mappers/file_annotations.rb
+++ b/lib/code_ownership/private/ownership_mappers/file_annotations.rb
@@ -18,7 +18,7 @@ module CodeOwnership
         extend T::Sig
         include Mapper
 
-        @@map_files_to_owners = T.let({}, T.nilable(T::Hash[String, T.nilable(::CodeTeams::Team)])) # rubocop:disable Style/ClassVars
+        @@map_files_to_owners = T.let({}, T.nilable(T::Hash[String, ::CodeTeams::Team])) # rubocop:disable Style/ClassVars
 
         TEAM_PATTERN = T.let(/\A(?:#|\/\/) @team (?<team>.*)\Z/.freeze, Regexp)
 
@@ -33,7 +33,7 @@ module CodeOwnership
         sig do
           override.
             params(files: T::Array[String]).
-            returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+            returns(T::Hash[String, ::CodeTeams::Team])
         end
         def map_files_to_owners(files)
           return @@map_files_to_owners if @@map_files_to_owners&.keys && @@map_files_to_owners.keys.count > 0
@@ -44,6 +44,24 @@ module CodeOwnership
 
             mapping[filename_relative_to_root] = owner
           end
+        end
+
+        sig do
+          override.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
+        end
+        def update_cache(cache, files)
+          cache.merge!(map_files_to_owners(files))
+
+          # TODO: Make `tracked_files` return a set
+          fileset = Set.new(Private.tracked_files)
+          invalid_files = cache.keys.select do |file|
+            !fileset.include?(file)
+          end
+          invalid_files.each do |invalid_file|
+            cache.delete(invalid_file)
+          end
+
+          cache
         end
 
         sig { params(filename: String).returns(T.nilable(CodeTeams::Team)) }

--- a/lib/code_ownership/private/ownership_mappers/file_annotations.rb
+++ b/lib/code_ownership/private/ownership_mappers/file_annotations.rb
@@ -35,7 +35,7 @@ module CodeOwnership
             params(files: T::Array[String]).
             returns(T::Hash[String, ::CodeTeams::Team])
         end
-        def map_files_to_owners(files)
+        def globs_to_owner(files)
           return @@map_files_to_owners if @@map_files_to_owners&.keys && @@map_files_to_owners.keys.count > 0
 
           @@map_files_to_owners = files.each_with_object({}) do |filename_relative_to_root, mapping| # rubocop:disable Style/ClassVars
@@ -50,7 +50,7 @@ module CodeOwnership
           override.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
         end
         def update_cache(cache, files)
-          cache.merge!(map_files_to_owners(files))
+          cache.merge!(globs_to_owner(files))
 
           # TODO: Make `tracked_files` return a set
           fileset = Set.new(Private.tracked_files)
@@ -112,14 +112,6 @@ module CodeOwnership
             new_file_contents = "#{new_lines.join("\n")}\n".gsub(/\A\n+/, '')
             filepath.write(new_file_contents)
           end
-        end
-
-        sig do
-          override.returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
-        end
-        def codeowners_lines_to_owners
-          @@map_files_to_owners = nil # rubocop:disable Style/ClassVars
-          map_files_to_owners(Private.tracked_files)
         end
 
         sig { override.returns(String) }

--- a/lib/code_ownership/private/ownership_mappers/js_package_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/js_package_ownership.rb
@@ -24,27 +24,10 @@ module CodeOwnership
         end
 
         sig do
-          override.
-            params(files: T::Array[String]).
-            returns(T::Hash[String, ::CodeTeams::Team])
-        end
-        def map_files_to_owners(files) # rubocop:disable Lint/UnusedMethodArgument
-          ParseJsPackages.all.each_with_object({}) do |package, res|
-            owner = owner_for_package(package)
-            next if owner.nil?
-
-            glob = package.directory.join('**/**').to_s
-            Dir.glob(glob).each do |path|
-              res[path] = owner
-            end
-          end
-        end
-
-        sig do
           override.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
         end
         def update_cache(cache, files)
-          codeowners_lines_to_owners
+          globs_to_owner(files)
         end
 
         #
@@ -56,9 +39,10 @@ module CodeOwnership
         # subset of files, but rather we want code ownership for all files.
         #
         sig do
-          override.returns(T::Hash[String, ::CodeTeams::Team])
+          override.params(files: T::Array[String]).
+            returns(T::Hash[String, ::CodeTeams::Team])
         end
-        def codeowners_lines_to_owners
+        def globs_to_owner(files)
           ParseJsPackages.all.each_with_object({}) do |package, res|
             owner = owner_for_package(package)
             next if owner.nil?

--- a/lib/code_ownership/private/ownership_mappers/js_package_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/js_package_ownership.rb
@@ -26,7 +26,7 @@ module CodeOwnership
         sig do
           override.
             params(files: T::Array[String]).
-            returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+            returns(T::Hash[String, ::CodeTeams::Team])
         end
         def map_files_to_owners(files) # rubocop:disable Lint/UnusedMethodArgument
           ParseJsPackages.all.each_with_object({}) do |package, res|
@@ -40,6 +40,13 @@ module CodeOwnership
           end
         end
 
+        sig do
+          override.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
+        end
+        def update_cache(cache, files)
+          codeowners_lines_to_owners
+        end
+
         #
         # Package ownership ignores the passed in files when generating code owners lines.
         # This is because Package ownership knows that the fastest way to find code owners for package based ownership
@@ -49,7 +56,7 @@ module CodeOwnership
         # subset of files, but rather we want code ownership for all files.
         #
         sig do
-          override.returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+          override.returns(T::Hash[String, ::CodeTeams::Team])
         end
         def codeowners_lines_to_owners
           ParseJsPackages.all.each_with_object({}) do |package, res|

--- a/lib/code_ownership/private/ownership_mappers/package_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/package_ownership.rb
@@ -26,7 +26,7 @@ module CodeOwnership
         sig do
           override.
             params(files: T::Array[String]).
-            returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+            returns(T::Hash[String, ::CodeTeams::Team])
         end
         def map_files_to_owners(files) # rubocop:disable Lint/UnusedMethodArgument
           Packs.all.each_with_object({}) do |package, res|
@@ -49,7 +49,7 @@ module CodeOwnership
         # subset of files, but rather we want code ownership for all files.
         #
         sig do
-          override.returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+          override.returns(T::Hash[String, ::CodeTeams::Team])
         end
         def codeowners_lines_to_owners
           Packs.all.each_with_object({}) do |package, res|
@@ -63,6 +63,13 @@ module CodeOwnership
         sig { override.returns(String) }
         def description
           'Owner metadata key in package.yml'
+        end
+
+        sig do
+          override.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
+        end
+        def update_cache(cache, files)
+          codeowners_lines_to_owners
         end
 
         sig { params(package: Packs::Pack).returns(T.nilable(CodeTeams::Team)) }

--- a/lib/code_ownership/private/ownership_mappers/package_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/package_ownership.rb
@@ -23,23 +23,6 @@ module CodeOwnership
           owner_for_package(package)
         end
 
-        sig do
-          override.
-            params(files: T::Array[String]).
-            returns(T::Hash[String, ::CodeTeams::Team])
-        end
-        def map_files_to_owners(files) # rubocop:disable Lint/UnusedMethodArgument
-          Packs.all.each_with_object({}) do |package, res|
-            owner = owner_for_package(package)
-            next if owner.nil?
-
-            glob = package.relative_path.join('**/**').to_s
-            Dir.glob(glob).each do |path|
-              res[path] = owner
-            end
-          end
-        end
-
         #
         # Package ownership ignores the passed in files when generating code owners lines.
         # This is because Package ownership knows that the fastest way to find code owners for package based ownership
@@ -49,9 +32,10 @@ module CodeOwnership
         # subset of files, but rather we want code ownership for all files.
         #
         sig do
-          override.returns(T::Hash[String, ::CodeTeams::Team])
+          override.params(files: T::Array[String]).
+            returns(T::Hash[String, ::CodeTeams::Team])
         end
-        def codeowners_lines_to_owners
+        def globs_to_owner(files)
           Packs.all.each_with_object({}) do |package, res|
             owner = owner_for_package(package)
             next if owner.nil?
@@ -69,7 +53,7 @@ module CodeOwnership
           override.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
         end
         def update_cache(cache, files)
-          codeowners_lines_to_owners
+          globs_to_owner(files)
         end
 
         sig { params(package: Packs::Pack).returns(T.nilable(CodeTeams::Team)) }

--- a/lib/code_ownership/private/ownership_mappers/team_globs.rb
+++ b/lib/code_ownership/private/ownership_mappers/team_globs.rb
@@ -16,9 +16,8 @@ module CodeOwnership
         @@codeowners_lines_to_owners = {} # rubocop:disable Style/ClassVars
 
         sig do
-          override.
-            params(files: T::Array[String]).
-            returns(T::Hash[String, ::CodeTeams::Team])
+          params(files: T::Array[String]).
+          returns(T::Hash[String, ::CodeTeams::Team])
         end
         def map_files_to_owners(files) # rubocop:disable Lint/UnusedMethodArgument
           return @@map_files_to_owners if @@map_files_to_owners&.keys && @@map_files_to_owners.keys.count > 0
@@ -96,13 +95,14 @@ module CodeOwnership
           override.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
         end
         def update_cache(cache, files)
-          codeowners_lines_to_owners
+          globs_to_owner(files)
         end
 
         sig do
-          override.returns(T::Hash[String, ::CodeTeams::Team])
+          override.params(files: T::Array[String]).
+            returns(T::Hash[String, ::CodeTeams::Team])
         end
-        def codeowners_lines_to_owners
+        def globs_to_owner(files)
           return @@codeowners_lines_to_owners if @@codeowners_lines_to_owners&.keys && @@codeowners_lines_to_owners.keys.count > 0
 
           @@codeowners_lines_to_owners = CodeTeams.all.each_with_object({}) do |team, map| # rubocop:disable Style/ClassVars

--- a/lib/code_ownership/private/ownership_mappers/team_globs.rb
+++ b/lib/code_ownership/private/ownership_mappers/team_globs.rb
@@ -10,15 +10,15 @@ module CodeOwnership
         include Mapper
         include Validator
 
-        @@map_files_to_owners = T.let(@map_files_to_owners, T.nilable(T::Hash[String, T.nilable(::CodeTeams::Team)])) # rubocop:disable Style/ClassVars
+        @@map_files_to_owners = T.let(@map_files_to_owners, T.nilable(T::Hash[String, ::CodeTeams::Team])) # rubocop:disable Style/ClassVars
         @@map_files_to_owners = {} # rubocop:disable Style/ClassVars
-        @@codeowners_lines_to_owners = T.let(@codeowners_lines_to_owners, T.nilable(T::Hash[String, T.nilable(::CodeTeams::Team)])) # rubocop:disable Style/ClassVars
+        @@codeowners_lines_to_owners = T.let(@codeowners_lines_to_owners, T.nilable(T::Hash[String, ::CodeTeams::Team])) # rubocop:disable Style/ClassVars
         @@codeowners_lines_to_owners = {} # rubocop:disable Style/ClassVars
 
         sig do
           override.
             params(files: T::Array[String]).
-            returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+            returns(T::Hash[String, ::CodeTeams::Team])
         end
         def map_files_to_owners(files) # rubocop:disable Lint/UnusedMethodArgument
           return @@map_files_to_owners if @@map_files_to_owners&.keys && @@map_files_to_owners.keys.count > 0
@@ -93,7 +93,14 @@ module CodeOwnership
         end
 
         sig do
-          override.returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+          override.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
+        end
+        def update_cache(cache, files)
+          codeowners_lines_to_owners
+        end
+
+        sig do
+          override.returns(T::Hash[String, ::CodeTeams::Team])
         end
         def codeowners_lines_to_owners
           return @@codeowners_lines_to_owners if @@codeowners_lines_to_owners&.keys && @@codeowners_lines_to_owners.keys.count > 0

--- a/lib/code_ownership/private/ownership_mappers/team_yml_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/team_yml_ownership.rb
@@ -15,9 +15,8 @@ module CodeOwnership
         @@codeowners_lines_to_owners = {} # rubocop:disable Style/ClassVars
 
         sig do
-          override.
-            params(files: T::Array[String]).
-            returns(T::Hash[String, ::CodeTeams::Team])
+          params(files: T::Array[String]).
+          returns(T::Hash[String, ::CodeTeams::Team])
         end
         def map_files_to_owners(files) # rubocop:disable Lint/UnusedMethodArgument
           return @@map_files_to_owners if @@map_files_to_owners&.keys && @@map_files_to_owners.keys.count > 0
@@ -36,9 +35,10 @@ module CodeOwnership
         end
 
         sig do
-          override.returns(T::Hash[String, ::CodeTeams::Team])
+          override.params(files: T::Array[String]).
+            returns(T::Hash[String, ::CodeTeams::Team])
         end
-        def codeowners_lines_to_owners
+        def globs_to_owner(files)
           return @@codeowners_lines_to_owners if @@codeowners_lines_to_owners&.keys && @@codeowners_lines_to_owners.keys.count > 0
 
           @@codeowners_lines_to_owners = CodeTeams.all.each_with_object({}) do |team, map| # rubocop:disable Style/ClassVars
@@ -56,7 +56,7 @@ module CodeOwnership
           override.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
         end
         def update_cache(cache, files)
-          codeowners_lines_to_owners
+          globs_to_owner(files)
         end
 
         sig { override.returns(String) }

--- a/lib/code_ownership/private/ownership_mappers/team_yml_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/team_yml_ownership.rb
@@ -9,15 +9,15 @@ module CodeOwnership
         extend T::Sig
         include Mapper
 
-        @@map_files_to_owners = T.let(@map_files_to_owners, T.nilable(T::Hash[String, T.nilable(::CodeTeams::Team)])) # rubocop:disable Style/ClassVars
+        @@map_files_to_owners = T.let(@map_files_to_owners, T.nilable(T::Hash[String, ::CodeTeams::Team])) # rubocop:disable Style/ClassVars
         @@map_files_to_owners = {} # rubocop:disable Style/ClassVars
-        @@codeowners_lines_to_owners = T.let(@codeowners_lines_to_owners, T.nilable(T::Hash[String, T.nilable(::CodeTeams::Team)])) # rubocop:disable Style/ClassVars
+        @@codeowners_lines_to_owners = T.let(@codeowners_lines_to_owners, T.nilable(T::Hash[String, ::CodeTeams::Team])) # rubocop:disable Style/ClassVars
         @@codeowners_lines_to_owners = {} # rubocop:disable Style/ClassVars
 
         sig do
           override.
             params(files: T::Array[String]).
-            returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+            returns(T::Hash[String, ::CodeTeams::Team])
         end
         def map_files_to_owners(files) # rubocop:disable Lint/UnusedMethodArgument
           return @@map_files_to_owners if @@map_files_to_owners&.keys && @@map_files_to_owners.keys.count > 0
@@ -36,7 +36,7 @@ module CodeOwnership
         end
 
         sig do
-          override.returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+          override.returns(T::Hash[String, ::CodeTeams::Team])
         end
         def codeowners_lines_to_owners
           return @@codeowners_lines_to_owners if @@codeowners_lines_to_owners&.keys && @@codeowners_lines_to_owners.keys.count > 0
@@ -50,6 +50,13 @@ module CodeOwnership
         def bust_caches!
           @@codeowners_lines_to_owners = {} # rubocop:disable Style/ClassVars
           @@map_files_to_owners = {} # rubocop:disable Style/ClassVars
+        end
+
+        sig do
+          override.params(cache: GlobsToOwningTeamMap, files: T::Array[String]).returns(GlobsToOwningTeamMap)
+        end
+        def update_cache(cache, files)
+          codeowners_lines_to_owners
         end
 
         sig { override.returns(String) }

--- a/spec/lib/code_ownership/private/extension_loader_spec.rb
+++ b/spec/lib/code_ownership/private/extension_loader_spec.rb
@@ -19,15 +19,6 @@ module CodeOwnership
           extend T::Sig
           include CodeOwnership::Mapper
           include CodeOwnership::Validator
-          
-          sig do
-            override.
-              params(files: T::Array[String]).
-              returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
-          end
-          def map_files_to_owners(files) # rubocop:disable Lint/UnusedMethodArgument
-            files.select{|f| Pathname.new(f).extname == '.rb'}.map{|f| [f, CodeTeams.all.last]}.to_h
-          end
 
           sig do
             override.params(file: String).
@@ -38,9 +29,10 @@ module CodeOwnership
           end
 
           sig do
-            override.returns(T::Hash[String, T.nilable(::CodeTeams::Team)])
+            override.params(files: T::Array[String]).
+              returns(T::Hash[String, ::CodeTeams::Team])
           end
-          def codeowners_lines_to_owners
+          def globs_to_owner(files)
             Dir.glob('**/*.rb').map{|f| [f, CodeTeams.all.last]}.to_h
           end
 

--- a/spec/lib/code_ownership/private/validations/files_have_unique_owners_spec.rb
+++ b/spec/lib/code_ownership/private/validations/files_have_unique_owners_spec.rb
@@ -64,12 +64,7 @@ module CodeOwnership
         end
 
         context 'the input files do not include the file owned in multiple ways' do
-          # This is currently skipped because during a test refactor I found this had a false positive since the input file did not exist.
-          # Currently, `FilesHaveUniqueOwners` doesn't respect input files since implementations of `OwnershipMappers::Interface#map_files_to_owners`
-          # are not respecting input files in some cases.
-          # We might want to either remove the ability to validate individual files (which is not particularly useful since codeowners regeneration, the longest step,
-          # cannot be done in piecemeal) OR update this validation to only consider input files.
-          skip 'ignores the file with multiple ownership' do
+          it 'ignores the file with multiple ownership' do
             expect { CodeOwnership.validate!(files: ['app/services/some_other_file.rb']) }.to_not raise_error
           end
         end


### PR DESCRIPTION
This PR allows the codeowners file to be used as a cache during validations. After pulling up the cache, we ask each mapper to update that cache given the input files. Then we use that cache to run our various validations.