### PR TITLE
Update README.md to reflect that CodeOwnership.for_class no longer takes a string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ See `code_ownership_spec.rb` for an example.
 `CodeOwnership.for_class` can be given a class and will either return `nil`, or a `CodeTeams::Team`.
 
 ```ruby
-CodeOwnership.for_class(MyClass.name)
+CodeOwnership.for_class(MyClass)
 ```
 
 Under the hood, this finds the file where the class is defined and returns the owner of that file.


### PR DESCRIPTION
`CodeOwnership.for_class` no longer takes a string according to the method signature. Update the readme to reflect that.