### PR TITLE
Return nil if class constant cannot be found

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,8 +60,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.4-x86_64-linux)
-      racc (~> 1.4)
     packs (0.0.6)
       sorbet-runtime
     packwerk (3.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_ownership (1.33.0)
+    code_ownership (1.33.1)
       code_teams (~> 1.0)
       packs
       sorbet-runtime (>= 0.5.10821)
@@ -59,6 +59,8 @@ GEM
     nokogiri (1.14.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.14.4-x86_64-linux)
       racc (~> 1.4)
     packs (0.0.6)
       sorbet-runtime

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'code_ownership'
-  spec.version       = '1.33.0'
+  spec.version       = '1.33.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership/private.rb
+++ b/lib/code_ownership/private.rb
@@ -70,6 +70,8 @@ module CodeOwnership
       else
         nil
       end
+    rescue NameError
+      nil
     end
 
     #

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -210,6 +210,12 @@ RSpec.describe CodeOwnership do
       expect(CodeOwnership).to_not have_received(:for_file)
       expect(Object).to_not have_received(:const_source_location)
     end
+
+    it 'returns nil if the class constant cannot be found' do
+      allow(CodeOwnership).to receive(:for_file)
+      allow(Object).to receive(:const_source_location).and_raise(NameError)
+      expect(CodeOwnership.for_class(MyFile)).to eq nil
+    end
   end
 
   describe '.for_team' do


### PR DESCRIPTION
When mocking controllers in Rspec, the class may be constructed in code, which means a class may look like `#<Class:0x000000015ea185d8>`, causing `Object.const_source_location` to fail. These should just return nil
