### PR TITLE
Update Github CodeTeam Plugin to enforce `github.team` presence

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_ownership (1.34.2)
+    code_ownership (1.35.0)
       code_teams (~> 1.0)
       packs-specification
       sorbet-runtime (>= 0.5.10821)

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'code_ownership'
-  spec.version       = '1.34.2'
+  spec.version       = '1.35.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership/configuration.rb
+++ b/lib/code_ownership/configuration.rb
@@ -11,6 +11,7 @@ module CodeOwnership
     const :unbuilt_gems_path, T.nilable(String)
     const :skip_codeowners_validation, T::Boolean
     const :raw_hash, T::Hash[T.untyped, T.untyped]
+    const :require_github_teams, T::Boolean
 
     sig { returns(Configuration) }
     def self.fetch
@@ -27,7 +28,8 @@ module CodeOwnership
         unowned_globs: config_hash.fetch('unowned_globs', []),
         js_package_paths: js_package_paths(config_hash),
         skip_codeowners_validation: config_hash.fetch('skip_codeowners_validation', false),
-        raw_hash: config_hash
+        raw_hash: config_hash,
+        require_github_teams: config_hash.fetch('require_github_teams', false)
       )
     end
 

--- a/lib/code_ownership/private/team_plugins/github.rb
+++ b/lib/code_ownership/private/team_plugins/github.rb
@@ -21,22 +21,13 @@ module CodeOwnership
 
         sig { override.params(teams: T::Array[CodeTeams::Team]).returns(T::Array[String]) }
         def self.validation_errors(teams)
-          all_github_teams = teams.flat_map { |team| self.for(team).github.team }
-          missing_github_teams = teams.select { |team| self.for(team).github.team.nil? }
+          all_github_teams = teams.flat_map { |team| self.for(team).github.team }.compact
 
           teams_used_more_than_once = all_github_teams.tally.select do |_team, count|
             count > 1
           end
 
           errors = T.let([], T::Array[String])
-
-          if missing_github_teams.any?
-            errors << <<~ERROR
-              The following teams are missing `github.team` entries
-
-              #{missing_github_teams.map(&:config_yml).join("\n")}
-            ERROR
-          end
 
           if teams_used_more_than_once.any?
             errors << <<~ERROR

--- a/lib/code_ownership/private/team_plugins/github.rb
+++ b/lib/code_ownership/private/team_plugins/github.rb
@@ -29,6 +29,18 @@ module CodeOwnership
 
           errors = T.let([], T::Array[String])
 
+          if require_github_teams?
+            missing_github_teams = teams.select { |team| self.for(team).github.team.nil? }
+
+            if missing_github_teams.any?
+              errors << <<~ERROR
+                The following teams are missing `github.team` entries:
+
+                #{missing_github_teams.map(&:config_yml).join("\n")}
+              ERROR
+            end
+          end
+
           if teams_used_more_than_once.any?
             errors << <<~ERROR
               The following teams are specified multiple times:
@@ -39,6 +51,11 @@ module CodeOwnership
           end
 
           errors
+        end
+
+        sig { returns(T::Boolean) }
+        def self.require_github_teams?
+          CodeOwnership.configuration.require_github_teams
         end
       end
     end

--- a/lib/code_ownership/private/team_plugins/github.rb
+++ b/lib/code_ownership/private/team_plugins/github.rb
@@ -22,12 +22,21 @@ module CodeOwnership
         sig { override.params(teams: T::Array[CodeTeams::Team]).returns(T::Array[String]) }
         def self.validation_errors(teams)
           all_github_teams = teams.flat_map { |team| self.for(team).github.team }
+          missing_github_teams = teams.select { |team| !team.raw_hash.dig('github', 'team') }
 
           teams_used_more_than_once = all_github_teams.tally.select do |_team, count|
             count > 1
           end
 
           errors = T.let([], T::Array[String])
+
+          if missing_github_teams.any?
+            errors << <<~ERROR
+              The following teams are missing `github.team` entries
+
+              #{missing_github_teams.map(&:config_yml).join("\n")}
+            ERROR
+          end
 
           if teams_used_more_than_once.any?
             errors << <<~ERROR

--- a/lib/code_ownership/private/team_plugins/github.rb
+++ b/lib/code_ownership/private/team_plugins/github.rb
@@ -22,7 +22,7 @@ module CodeOwnership
         sig { override.params(teams: T::Array[CodeTeams::Team]).returns(T::Array[String]) }
         def self.validation_errors(teams)
           all_github_teams = teams.flat_map { |team| self.for(team).github.team }
-          missing_github_teams = teams.select { |team| !team.raw_hash.dig('github', 'team') }
+          missing_github_teams = teams.select { |team| self.for(team).github.team.nil? }
 
           teams_used_more_than_once = all_github_teams.tally.select do |_team, count|
             count > 1

--- a/spec/lib/code_ownership/private/validations/github_codeowners_up_to_date_spec.rb
+++ b/spec/lib/code_ownership/private/validations/github_codeowners_up_to_date_spec.rb
@@ -757,27 +757,49 @@ module CodeOwnership
     end
 
     describe 'uniqueness of github teams' do
-      before do
-        write_configuration
+      context 'when the CodeTeam has a github.team key' do
+        before do
+          write_configuration
 
-        write_file('config/teams/bar.yml', <<~CONTENTS)
-          name: Bar
-          github:
-            team: '@MyOrg/bar-team'
-        CONTENTS
+          write_file('config/teams/bar.yml', <<~CONTENTS)
+            name: Bar
+            github:
+              team: '@MyOrg/bar-team'
+          CONTENTS
 
-        write_file('config/teams/foo.yml', <<~CONTENTS)
-          name: Bar
-          github:
-            team: '@MyOrg/bar-team'
-        CONTENTS
+          write_file('config/teams/foo.yml', <<~CONTENTS)
+            name: Bar
+            github:
+              team: '@MyOrg/bar-team'
+          CONTENTS
+        end
+
+        it 'expect code teams validations to fail' do
+          expect(CodeTeams.validation_errors(CodeTeams.all)).to eq([
+            "More than 1 definition for Bar found",
+            "The following teams are specified multiple times:\nEach code team must have a unique GitHub team in order to write the CODEOWNERS file correctly.\n\n@MyOrg/bar-team\n"
+          ])
+        end
       end
 
-      it 'expect code teams validations to fail' do
-        expect(CodeTeams.validation_errors(CodeTeams.all)).to eq([
-          "More than 1 definition for Bar found",
-          "The following teams are specified multiple times:\nEach code team must have a unique GitHub team in order to write the CODEOWNERS file correctly.\n\n@MyOrg/bar-team\n"
-        ])
+      context 'when the CodeTeam does not have a github.team key' do
+        before do
+          write_configuration
+
+          write_file('config/teams/bar.yml', <<~CONTENTS)
+            name: Bar
+          CONTENTS
+
+          write_file('config/teams/foo.yml', <<~CONTENTS)
+            name: Bar
+          CONTENTS
+        end
+
+        it 'does not report CodeTeams without github.teams key' do
+          expect(CodeTeams.validation_errors(CodeTeams.all)).to eq([
+            "More than 1 definition for Bar found"
+          ])
+        end
       end
     end
 

--- a/spec/lib/code_ownership/private/validations/github_codeowners_up_to_date_spec.rb
+++ b/spec/lib/code_ownership/private/validations/github_codeowners_up_to_date_spec.rb
@@ -780,5 +780,37 @@ module CodeOwnership
         ])
       end
     end
+
+    describe 'require_github_teams configuration option' do
+      before do
+        write_configuration('require_github_teams' => require_github_teams)
+
+        write_file('config/teams/foo.yml', <<~CONTENTS)
+          name: Foo
+        CONTENTS
+
+        write_file('config/teams/bar.yml', <<~CONTENTS)
+          name: Bar
+        CONTENTS
+      end
+
+      context 'when require_github_teams is enabled' do
+        let(:require_github_teams) { true }
+
+        it 'reports CodeTeams without github.team keys' do
+          expect(CodeTeams.validation_errors(CodeTeams.all)).to eq([
+            "The following teams are missing `github.team` entries:\n\nconfig/teams/bar.yml\nconfig/teams/foo.yml\n"
+          ])
+        end
+      end
+
+      context 'when require_github_teams is disabled' do
+        let(:require_github_teams) { false }
+
+        it 'does not report any errors' do
+          expect(CodeTeams.validation_errors(CodeTeams.all)).to be_empty
+        end
+      end
+    end
   end
 end

--- a/spec/lib/code_ownership/private/validations/github_codeowners_up_to_date_spec.rb
+++ b/spec/lib/code_ownership/private/validations/github_codeowners_up_to_date_spec.rb
@@ -758,6 +758,8 @@ module CodeOwnership
 
     describe 'uniqueness of github teams' do
       before do
+        write_configuration
+
         write_file('config/teams/bar.yml', <<~CONTENTS)
           name: Bar
           github:


### PR DESCRIPTION
## Issue

The Github CodeTeam Plugin only enforces that more than one CodeTeam does not have a duplicate `github.team` value. The validation error message is not specific if more than one CodeTeam do not have `github.team` keys. 

Given two CodeTeam YAML files with no `github.team` key, the validation errors produces the follow error message:

```ruby
irb(main):001:0>  CodeTeams.validation_errors(CodeTeams.all)
=> ["The following teams are specified multiple times:\nEach code team must have a unique GitHub team in order to write the CODEOWNERS file correctly.\n\n\n"]
```

It is not clear which CodeTeams are the offenders.

## Solution

Update the Plugin to check that each CodeTeam has a `github.team` key.

```ruby
irb(main):001:0> CodeTeams.validation_errors(CodeTeams.all)
=>
["The following teams are missing `github.team` entries\n\nconfig/teams/one.yml\nconfig/teams/two.yml\n",
 "The following teams are specified multiple times:\nEach code team must have a unique GitHub team in order to write the CODEOWNERS file correctly.\n\n\n"]
```

This still prints the original, unspecific error message, but at least there's context on the files that are missing `github.team` keys. If we want to remove the `nil` Github teams from the original error message, we could `#compact` on the `flat_map`. 

## Reproduction

- Create a new rails project, `rails new`
- `bundle add code_teams`
- `bundle add code_ownership`
- Add the following CodeTeam YAML files to `config/teams`
  ```yaml
  # config/teams/one.yml
  ---
  name: one
  ```
  ```yaml
  # config/teams/two.yml
  ---
  name: two
  ```
- Start a `rails console` and run `CodeTeams.validation_errors(CodeTeams.all)` 
