### PR TITLE
Switch directory ownership to `git ls-files`

### DIFF
--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -85,14 +85,17 @@ module CodeOwnership
       autocorrect: T::Boolean,
       stage_changes: T::Boolean,
       files: T.nilable(T::Array[String]),
+      use_git_ls_files: T::Boolean,
     ).void
   end
   def validate!(
     autocorrect: true,
     stage_changes: true,
-    files: nil
+    files: nil,
+    use_git_ls_files: false
   )
     Private.load_configuration!
+    configuration.use_git_ls_files = use_git_ls_files
 
     tracked_file_subset = if files
       files.select{|f| Private.file_tracked?(f)}

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -48,7 +48,7 @@ module CodeOwnership
           options[:skip_stage] = true
         end
 
-        opts.on('-use-git-ls-files',
+        opts.on('--use-git-ls-files',
                 'Use git ls-files for findinging .codeowner files instead of globs. Will be faster if in a git context.') do
           CodeOwnership::Configuration.use_git_ls_files = true
         end

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -48,6 +48,11 @@ module CodeOwnership
           options[:skip_stage] = true
         end
 
+        opts.on('-use-git-ls-files',
+                'Use git ls-files for findinging .codeowner files instead of globs. Will be faster if in a git context.') do
+          CodeOwnership::Configuration.use_git_ls_files = true
+        end
+
         opts.on('--help', 'Shows this prompt') do
           puts opts
           exit

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -50,7 +50,7 @@ module CodeOwnership
 
         opts.on('--use-git-ls-files',
                 'Use git ls-files for findinging .codeowner files instead of globs. Will be faster if in a git context.') do
-          CodeOwnership::Configuration.use_git_ls_files = true
+          options[:use_git_ls_files] = true
         end
 
         opts.on('--help', 'Shows this prompt') do
@@ -72,7 +72,8 @@ module CodeOwnership
       CodeOwnership.validate!(
         files: files,
         autocorrect: !options[:skip_autocorrect],
-        stage_changes: !options[:skip_stage]
+        stage_changes: !options[:skip_stage],
+        use_git_ls_files: !!options[:use_git_ls_files]
       )
     end
 

--- a/lib/code_ownership/configuration.rb
+++ b/lib/code_ownership/configuration.rb
@@ -12,6 +12,7 @@ module CodeOwnership
     const :skip_codeowners_validation, T::Boolean
     const :raw_hash, T::Hash[T.untyped, T.untyped]
     const :require_github_teams, T::Boolean
+    const :use_git_ls_files, T::Boolean
 
     sig { returns(Configuration) }
     def self.fetch
@@ -29,7 +30,8 @@ module CodeOwnership
         js_package_paths: js_package_paths(config_hash),
         skip_codeowners_validation: config_hash.fetch('skip_codeowners_validation', false),
         raw_hash: config_hash,
-        require_github_teams: config_hash.fetch('require_github_teams', false)
+        require_github_teams: config_hash.fetch('require_github_teams', false),
+        use_git_ls_files: config_hash.fetch('use_git_ls_files', false)
       )
     end
 

--- a/lib/code_ownership/configuration.rb
+++ b/lib/code_ownership/configuration.rb
@@ -12,7 +12,7 @@ module CodeOwnership
     const :skip_codeowners_validation, T::Boolean
     const :raw_hash, T::Hash[T.untyped, T.untyped]
     const :require_github_teams, T::Boolean
-    const :use_git_ls_files, T::Boolean
+    prop :use_git_ls_files, T::Boolean
 
     sig { returns(Configuration) }
     def self.fetch

--- a/lib/code_ownership/private/ownership_mappers/directory_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/directory_ownership.rb
@@ -37,14 +37,22 @@ module CodeOwnership
         # subset of files, but rather we want code ownership for all files.
         #
         sig do
-          override.params(files: T::Array[String]).
-            returns(T::Hash[String, ::CodeTeams::Team])
+          override.params(_files: T::Array[String])
+                  .returns(T::Hash[String, ::CodeTeams::Team])
         end
-        def globs_to_owner(files)
-          `git ls-files **/#{CODEOWNERS_DIRECTORY_FILE_NAME}`
-            .each_line
-            .each_with_object({}) do |fname, res|
-            pathname = Pathname.new(fname.strip).cleanpath
+        def globs_to_owner(_files)
+          file_list =
+            if CodeOwnership.configuration.use_git_ls_files
+              `git ls-files **/#{CODEOWNERS_DIRECTORY_FILE_NAME}`
+                .each_line
+                .map { Pathname.new(_1.strip).cleanpath }
+            else
+              T
+                .unsafe(Pathname)
+                .glob(File.join('**/', CODEOWNERS_DIRECTORY_FILE_NAME))
+                .map(&:cleanpath)
+            end
+          file_list.each_with_object({}) do |pathname, res|
             owner = owner_for_codeowners_file(pathname)
             res[pathname.dirname.cleanpath.join('**/**').to_s] = owner
           end

--- a/lib/code_ownership/private/ownership_mappers/directory_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/directory_ownership.rb
@@ -41,12 +41,10 @@ module CodeOwnership
             returns(T::Hash[String, ::CodeTeams::Team])
         end
         def globs_to_owner(files)
-          # The T.unsafe is because the upstream RBI is wrong for Pathname.glob
-          T
-            .unsafe(Pathname)
-            .glob(File.join('**/', CODEOWNERS_DIRECTORY_FILE_NAME))
-            .map(&:cleanpath)
-            .each_with_object({}) do |pathname, res|
+          `git ls-files **/#{CODEOWNERS_DIRECTORY_FILE_NAME}`
+            .each_line
+            .each_with_object({}) do |fname, res|
+            pathname = Pathname.new(fname.strip).cleanpath
             owner = owner_for_codeowners_file(pathname)
             res[pathname.dirname.cleanpath.join('**/**').to_s] = owner
           end

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe CodeOwnership do
           expect { CodeOwnership.validate!(files: ['app/services/test/some_unowned_file.rb']) }.to_not raise_error
           expect { CodeOwnership.validate!(files: ['app/services/[test]/some_unowned_file.rb']) }.to_not raise_error
         end
+
+        context 'when the the configuration for use_git_ls_files is enabled' do
+          before do
+            allow(CodeOwnership.configuration).to receive(:use_git_ls_files) { true }
+            allow_any_instance_of(Object).to receive(:`) do
+              Pathname
+                .glob(File.join('**/', '.codeowner'))
+                .map(&:to_s)
+                .join("\n")
+            end
+          end
+
+          it 'has no validation errors' do
+            expect { CodeOwnership.validate!(files: ['app/services/test/some_unowned_file.rb']) }.to_not raise_error
+            expect { CodeOwnership.validate!(files: ['app/services/[test]/some_unowned_file.rb']) }.to_not raise_error
+          end
+        end
       end
 
       context 'file ownership with [] characters' do


### PR DESCRIPTION
This switches away from using a glob match on '**' within
`DirectoryOwnership` matcher in favour of using `git ls-files`. This
provides a significant speed improvement for large repositories for a
few reasons.

The primary reason is that we're only searching through tracked files
and avoiding potentially large directores, such as `node_modules`.

The major intended side effect of this is that it only is dealing with
tracked files rather than all files.

I'm opening the PR for further discussion and refinement to see if this
is worth considering.

Speed comparison for me locally:

Before:
```
❯ time bin/codeownership validate

________________________________________________________
Executed in   16.72 secs    fish           external
   usr time    3.08 secs    0.10 millis    3.08 secs
   sys time   10.70 secs    1.59 millis   10.70 secs
```

After:
```
❯ time bin/codeownership validate

________________________________________________________
Executed in   10.67 secs    fish           external
   usr time    2.90 secs  111.00 micros    2.90 secs
   sys time    8.65 secs  741.00 micros    8.65 secs
```
