### PR TITLE
Fix `validate --diff` when multiple owned globs are present

### DIFF
--- a/lib/code_ownership/private.rb
+++ b/lib/code_ownership/private.rb
@@ -92,7 +92,7 @@ module CodeOwnership
       # However, globbing out can take 5 or more seconds on a large repository, dramatically slowing down
       # invocations to `bin/codeownership validate --diff`.
       # Using `File.fnmatch?` is a lot faster!
-      in_owned_globs = configuration.owned_globs.all? do |owned_glob|
+      in_owned_globs = configuration.owned_globs.any? do |owned_glob|
         File.fnmatch?(owned_glob, file, File::FNM_PATHNAME | File::FNM_EXTGLOB)
       end
 

--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -3,9 +3,10 @@ RSpec.describe CodeOwnership::Cli do
 
   describe 'validate' do
     let(:argv) { ['validate'] }
+    let(:owned_globs) { nil }
 
     before do
-      write_configuration
+      write_configuration(owned_globs: owned_globs)
       write_file('app/services/my_file.rb')
       write_file('frontend/javascripts/my_file.jsx')
     end
@@ -21,6 +22,22 @@ RSpec.describe CodeOwnership::Cli do
       end
     end
 
+    context 'with --diff argument' do
+      let(:argv) { ['validate', '--diff'] }
+
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('CODEOWNERS_GIT_STAGED_FILES').and_return('app/services/my_file.rb')
+      end
+
+      context 'when there are multiple owned_globs' do
+        let(:owned_globs) { ['app/*/**', 'lib/*/**'] }
+
+        it 'validates the tracked file' do
+          expect { subject }.to raise_error CodeOwnership::InvalidCodeOwnershipConfigurationError
+        end
+      end
+    end
   end
 
   describe 'for_file' do


### PR DESCRIPTION
When multiple owned globs are present `file_tracked?` expects a given file to be present in every owned glob. This leads to differing behavior between `file_tracked? file` and `tracked_files.include? file`.

Based on the comments and my experience trying to use the cli with `validate --diff`, I think the implementation in `file_tracked?` should be changed to match the behavior of the other methods that check for file inclusion.