### PR TITLE
escape globs derived from .codeowner files

### DIFF
--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'code_ownership'
-  spec.version       = '1.36.3'
+  spec.version       = '1.37.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership/private/ownership_mappers/directory_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/directory_ownership.rb
@@ -130,10 +130,10 @@ module CodeOwnership
           unescaped = codeowners_file.dirname.cleanpath.join('**/**').to_s
 
           # Globs can contain certain regex characters, like "[" and "]".
-          # However, when we are generating a glob from a .codeowners file, we
+          # However, when we are generating a glob from a .codeowner file, we
           # need to escape bracket characters and interpret them literally.
           # Otherwise the resulting glob will not actually match the directory
-          # containing the .codeowners file.
+          # containing the .codeowner file.
           #
           # Example
           # file: "/some/[dir]/.codeowner"

--- a/lib/code_ownership/private/ownership_mappers/directory_ownership.rb
+++ b/lib/code_ownership/private/ownership_mappers/directory_ownership.rb
@@ -132,7 +132,7 @@ module CodeOwnership
           # Globs can contain certain regex characters, like "[" and "]".
           # However, when we are generating a glob from a .codeowners file, we
           # need to escape bracket characters and interpret them literally.
-          # Otherise the resulting glob will not actually match the directory
+          # Otherwise the resulting glob will not actually match the directory
           # containing the .codeowners file.
           #
           # Example

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -161,6 +161,19 @@ RSpec.describe CodeOwnership do
       end
     end
 
+    context '.codeowner in a directory with [] characters' do
+      before do
+        write_file('app/javascript/[test]/.codeowner', <<~CONTENTS)
+          Bar
+        CONTENTS
+        write_file('app/javascript/[test]/test.js', '')
+      end
+
+      it 'properly assigns ownership' do
+        expect(CodeOwnership.for_file('app/javascript/[test]/test.js')).to eq CodeTeams.find('Bar')
+      end
+    end
+
     before { create_non_empty_application }
   end
 

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe CodeOwnership do
         end
       end
 
+      context 'directory with [] characters containing a .codeowner file' do
+        before do
+          write_file('app/services/[test]/.codeowner', <<~CONTENTS)
+            Bar
+          CONTENTS
+          write_file('app/services/[test]/some_file.rb', '')
+        end
+
+        it 'has no validation errors' do
+          expect { CodeOwnership.validate!(files: ['app/services/[test]/some_file.rb']) }.to_not raise_error
+        end
+      end
+
       context 'file ownership with [] characters' do
         before do
           write_file('app/services/[test]/some_file.ts', <<~TYPESCRIPT)


### PR DESCRIPTION
Globs can contain certain regex characters, like "[" and "]". However, when we are generating a glob from a .codeowners file, we need to escape bracket characters and interpret them literally. Otherwise the resulting glob will not actually match the directory containing the .codeowners file.

* Fixes https://github.com/rubyatscale/code_ownership/issues/103

## Example
```
file: "/some/[dir]/.codeowner"
unescaped: "/some/[dir]/**/**"
matches: "/some/d/file"
matches: "/some/i/file"
matches: "/some/r/file"
does not match!: "/some/[dir]/file"
```