### PR TITLE
escape brackets for files owned with a file annotation

### DIFF
--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'code_ownership'
-  spec.version       = '1.37.0'
+  spec.version       = '1.38.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership/private.rb
+++ b/lib/code_ownership/private.rb
@@ -99,6 +99,7 @@ module CodeOwnership
       in_unowned_globs = configuration.unowned_globs.any? do |unowned_glob|
         File.fnmatch?(unowned_glob, file, File::FNM_PATHNAME | File::FNM_EXTGLOB)
       end
+
       in_owned_globs && !in_unowned_globs && File.exist?(file)
     end
 

--- a/spec/lib/code_ownership/private/ownership_mappers/file_annotations_spec.rb
+++ b/spec/lib/code_ownership/private/ownership_mappers/file_annotations_spec.rb
@@ -70,6 +70,23 @@ module CodeOwnership
           expect(CodeOwnership.for_file('frontend/javascripts/packages/my_package/owned_file.jsx').name).to eq 'Bar'
         end
       end
+
+      context 'javascript owned file with brackets' do
+        before do
+          write_configuration
+          write_file('config/teams/bar.yml', <<~CONTENTS)
+            name: Bar
+          CONTENTS
+
+          write_file('frontend/javascripts/packages/my_package/[formID]/owned_file.jsx', <<~CONTENTS)
+            // @team Bar
+          CONTENTS
+        end
+
+        it 'can find the owner of a javascript file with file annotations' do
+          expect(CodeOwnership.for_file('frontend/javascripts/packages/my_package/[formID]/owned_file.jsx').name).to eq 'Bar'
+        end
+      end
     end
 
     describe '.remove_file_annotation!' do


### PR DESCRIPTION
- [x]  Update version

## Background
When a file has special characters (brackets in this case) escaped with a backslash (e.g. `\[taskId\]`), the file shows the appropriate owner on Github.

When a file has special characters that are not escaped (e.g. `[taskId]`), it does not show an owner on Github.

## Change
Modifies `code_ownership` to escape special characters for files with ownership declared with file annotations. This change was already made for escaping globs derived from .codeowner files: https://github.com/rubyatscale/code_ownership/pull/106