### PR TITLE
Add special sorting for special characters in globs

### DIFF
--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'code_ownership'
-  spec.version       = '1.38.0'
+  spec.version       = '1.38.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/spec/lib/code_ownership/private/validations/github_codeowners_up_to_date_spec.rb
+++ b/spec/lib/code_ownership/private/validations/github_codeowners_up_to_date_spec.rb
@@ -53,6 +53,7 @@ module CodeOwnership
 
               # Owner in .codeowner
               /directory/owner/**/** @MyOrg/bar-team
+              /directory/owner/(my_folder)/**/** @MyOrg/foo-team
 
               # Owner metadata key in package.yml
               /packs/my_other_package/**/** @MyOrg/bar-team
@@ -62,6 +63,7 @@ module CodeOwnership
 
               # Team YML ownership
               /config/teams/bar.yml @MyOrg/bar-team
+              /config/teams/foo.yml @MyOrg/foo-team
             EXPECTED
           end
 
@@ -90,6 +92,7 @@ module CodeOwnership
 
                 # Owner in .codeowner
                 /directory/owner/**/** @MyOrg/bar-team
+                /directory/owner/(my_folder)/**/** @MyOrg/foo-team
 
                 # Owner metadata key in package.yml
                 /packs/my_other_package/**/** @MyOrg/bar-team
@@ -99,6 +102,7 @@ module CodeOwnership
 
                 # Team YML ownership
                 /config/teams/bar.yml @MyOrg/bar-team
+                /config/teams/foo.yml @MyOrg/foo-team
               EXPECTED
             end
           end
@@ -126,6 +130,12 @@ module CodeOwnership
                 # code/file owner is notified. Reference GitHub docs for more details:
                 # https://help.github.com/en/articles/about-code-owners
 
+
+                # Owner in .codeowner
+                /directory/owner/(my_folder)/**/** @MyOrg/foo-team
+
+                # Team YML ownership
+                /config/teams/foo.yml @MyOrg/foo-team
               EXPECTED
             end
           end
@@ -167,6 +177,7 @@ module CodeOwnership
 
                 # Owner in .codeowner
                 # /directory/owner/**/** @MyOrg/bar-team
+                /directory/owner/(my_folder)/**/** @MyOrg/foo-team
 
                 # Owner metadata key in package.yml
                 # /packs/my_other_package/**/** @MyOrg/bar-team
@@ -176,6 +187,7 @@ module CodeOwnership
 
                 # Team YML ownership
                 # /config/teams/bar.yml @MyOrg/bar-team
+                /config/teams/foo.yml @MyOrg/foo-team
               EXPECTED
             end
           end
@@ -336,8 +348,10 @@ module CodeOwnership
 
                 CODEOWNERS should contain the following lines, but does not:
                 - "/packs/my_pack/owned_file.rb @MyOrg/bar-team"
+                - "/config/teams/foo.yml @MyOrg/foo-team"
                 - "# Owner in .codeowner"
                 - "/directory/owner/**/** @MyOrg/bar-team"
+                - "/directory/owner/(my_folder)/**/** @MyOrg/foo-team"
                 - "# Owner metadata key in package.yml"
                 - "/packs/my_other_package/**/** @MyOrg/bar-team"
 
@@ -377,6 +391,7 @@ module CodeOwnership
 
               # Owner in .codeowner
               /directory/owner/**/** @MyOrg/bar-team
+              /directory/owner/(my_folder)/**/** @MyOrg/foo-team
 
               # Owner metadata key in package.yml
               /packs/my_other_package/**/** @MyOrg/bar-team
@@ -388,6 +403,7 @@ module CodeOwnership
 
               # Team YML ownership
               /config/teams/bar.yml @MyOrg/bar-team
+              /config/teams/foo.yml @MyOrg/foo-team
             CODEOWNERS
 
             expect_any_instance_of(codeowners_validation).to_not receive(:`)
@@ -443,8 +459,10 @@ module CodeOwnership
 
                 CODEOWNERS should contain the following lines, but does not:
                 - "/packs/my_pack/owned_file.rb @MyOrg/bar-team"
+                - "/config/teams/foo.yml @MyOrg/foo-team"
                 - "# Owner in .codeowner"
                 - "/directory/owner/**/** @MyOrg/bar-team"
+                - "/directory/owner/(my_folder)/**/** @MyOrg/foo-team"
                 - "# Owner metadata key in package.yml"
                 - "/packs/my_other_package/**/** @MyOrg/bar-team"
 
@@ -475,6 +493,7 @@ module CodeOwnership
 
               # Owner in .codeowner
               /directory/owner/**/** @MyOrg/bar-team
+              /directory/owner/(my_folder)/**/** @MyOrg/foo-team
 
               # Owner metadata key in package.yml
               /packs/my_other_package/**/** @MyOrg/bar-team
@@ -488,6 +507,7 @@ module CodeOwnership
 
               # Team YML ownership
               /config/teams/bar.yml @MyOrg/bar-team
+              /config/teams/foo.yml @MyOrg/foo-team
             CODEOWNERS
 
             expect_any_instance_of(codeowners_validation).to_not receive(:`)
@@ -516,6 +536,7 @@ module CodeOwnership
 
               # Owner in .codeowner
               /directory/owner/**/** @MyOrg/bar-team
+              /directory/owner/(my_folder)/**/** @MyOrg/foo-team
 
               # Owner metadata key in package.yml
               /packs/my_other_package/**/** @MyOrg/bar-team
@@ -529,6 +550,7 @@ module CodeOwnership
 
               # Team YML ownership
               /config/teams/bar.yml @MyOrg/bar-team
+              /config/teams/foo.yml @MyOrg/foo-team
             CODEOWNERS
 
             expect_any_instance_of(codeowners_validation).to_not receive(:`)

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe CodeOwnership do
-  # Look at individual validations spec to see other validaions that ship with CodeOwnership
+  # Look at individual validations spec to see other validations that ship with CodeOwnership
   describe '.validate!' do
     describe 'teams must exist validation' do
       before do

--- a/spec/support/application_fixtures.rb
+++ b/spec/support/application_fixtures.rb
@@ -25,6 +25,10 @@ RSpec.shared_context 'application fixtures' do
       Bar
     CONTENTS
     write_file('directory/owner/some_directory_file.ts')
+    write_file('directory/owner/(my_folder)/.codeowner', <<~CONTENTS)
+      Foo
+    CONTENTS
+    write_file('directory/owner/(my_folder)/some_other_file.ts')
 
     write_file('frontend/javascripts/packages/my_other_package/package.json', <<~CONTENTS)
       {
@@ -35,6 +39,12 @@ RSpec.shared_context 'application fixtures' do
       }
     CONTENTS
     write_file('frontend/javascripts/packages/my_other_package/my_file.jsx')
+
+    write_file('config/teams/foo.yml', <<~CONTENTS)
+      name: Foo
+      github:
+        team: '@MyOrg/foo-team'
+    CONTENTS
 
     write_file('config/teams/bar.yml', <<~CONTENTS)
       name: Bar


### PR DESCRIPTION
### Situation
`/frontend/packages/my-thing/src/pages/blah` is owned by Foo via a `.codeowner` file

`/frontend/packages/my-thing/src/pages/blah/(bar)` is owned by Bar via a `.codeowner` file

### Expected Behavior
The most specific (nested) `.codeowner` file should take precedence, so `/frontend/packages/my-thing/src/pages/blah/(bar)/Sidebar.test.tsx` should be owned by Bar.

### Actual Behavior
`/frontend/packages/my-thing/src/pages/blah/(bar)/Sidebar.test.tsx` shows that it is owned by Foo. This is because `/frontend/packages/my-thing/src/pages/blah/(bar)` is written above `/frontend/packages/my-thing/src/pages/blah` in the `CODEOWNERS` file.

### This change
This change updates the file sorting such that if two globs match up until a `**`, then the one without the `**` at that location will be prioritized. This ensures that the more specific folder will come last, which means that the file will show the proper owner.

- [x] TODO: test this on a large repo before merging

Performance seems comparable