### PR TITLE
feat: match ruby 3.4 backtrace changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - 3.1
           - 3.2
           - 3.3
+          - 3.4
     env:
       BUNDLE_GEMFILE: Gemfile
     name: "RSpec tests: Ruby ${{ matrix.ruby }}"

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'code_ownership'
-  spec.version       = '1.38.1'
+  spec.version       = '1.38.2'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -136,13 +136,23 @@ module CodeOwnership
     #
     #   ./app/controllers/some_controller.rb:43:in `block (3 levels) in create'
     #
-    backtrace_line = %r{\A(#{Pathname.pwd}/|\./)?
-        (?<file>.+)       # Matches 'app/controllers/some_controller.rb'
-        :
-        (?<line>\d+)      # Matches '43'
-        :in\s
-        `(?<function>.*)' # Matches "`block (3 levels) in create'"
-      \z}x
+    backtrace_line = if RUBY_VERSION >= '3.4.0'
+      %r{\A(#{Pathname.pwd}/|\./)?
+          (?<file>.+)       # Matches 'app/controllers/some_controller.rb'
+          :
+          (?<line>\d+)      # Matches '43'
+          :in\s
+          '(?<function>.*)' # Matches "`block (3 levels) in create'"
+        \z}x
+    else
+      %r{\A(#{Pathname.pwd}/|\./)?
+          (?<file>.+)       # Matches 'app/controllers/some_controller.rb'
+          :
+          (?<line>\d+)      # Matches '43'
+          :in\s
+          `(?<function>.*)' # Matches "`block (3 levels) in create'"
+        \z}x
+    end
 
     backtrace.lazy.filter_map do |line|
       match = line.match(backtrace_line)


### PR DESCRIPTION
Ruby 3.4 changes backtrace from using backtick to single quote, fix our regex and use simple if/else to make it compatible with ruby 3.4.