### PR TITLE
Use environment variable to set CODEOWNERS write path

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ bin/codeownership for_team 'My Team' > tmp/ownership_report.md
 
 A `CODEOWNERS` file defines who owns specific files or paths in a repository. When you run `bin/codeownership validate`, a `.github/CODEOWNERS` file will automatically be generated and updated.
 
+If the `CODEOWNERS_PATH` environment variable is set, codeowners will use that path to generate the `CODEOWNERS` file. For example, `CODEOWNERS=docs` will generate `docs/CODEOWNERS`.
+
 ## Proper Configuration & Validation
 
 CodeOwnership comes with a validation function to ensure the following things are true:

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ bin/codeownership for_team 'My Team' > tmp/ownership_report.md
 
 A `CODEOWNERS` file defines who owns specific files or paths in a repository. When you run `bin/codeownership validate`, a `.github/CODEOWNERS` file will automatically be generated and updated.
 
-If the `CODEOWNERS_PATH` environment variable is set, codeowners will use that path to generate the `CODEOWNERS` file. For example, `CODEOWNERS=docs` will generate `docs/CODEOWNERS`.
+If the `CODEOWNERS_PATH` environment variable is set, codeowners will use that path to generate the `CODEOWNERS` file. For example, `CODEOWNERS_PATH=docs` will generate `docs/CODEOWNERS`.
 
 ## Proper Configuration & Validation
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ bin/codeownership for_team 'My Team' > tmp/ownership_report.md
 
 A `CODEOWNERS` file defines who owns specific files or paths in a repository. When you run `bin/codeownership validate`, a `.github/CODEOWNERS` file will automatically be generated and updated.
 
-If the `CODEOWNERS_PATH` environment variable is set, codeowners will use that path to generate the `CODEOWNERS` file. For example, `CODEOWNERS_PATH=docs` will generate `docs/CODEOWNERS`.
+If `codeowners_path` is set in `code_ownership.yml` codeowners will use that path to generate the `CODEOWNERS` file. For example, `codeowners_path: docs` will generate `docs/CODEOWNERS`.
 
 ## Proper Configuration & Validation
 

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'code_ownership'
-  spec.version       = '1.38.2'
+  spec.version       = '1.38.3'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership/configuration.rb
+++ b/lib/code_ownership/configuration.rb
@@ -12,6 +12,7 @@ module CodeOwnership
     const :skip_codeowners_validation, T::Boolean
     const :raw_hash, T::Hash[T.untyped, T.untyped]
     const :require_github_teams, T::Boolean
+    const :codeowners_path, String
 
     sig { returns(Configuration) }
     def self.fetch
@@ -29,7 +30,8 @@ module CodeOwnership
         js_package_paths: js_package_paths(config_hash),
         skip_codeowners_validation: config_hash.fetch('skip_codeowners_validation', false),
         raw_hash: config_hash,
-        require_github_teams: config_hash.fetch('require_github_teams', false)
+        require_github_teams: config_hash.fetch('require_github_teams', false),
+        codeowners_path: config_hash.fetch('codeowners_path', '.github'),
       )
     end
 

--- a/lib/code_ownership/private/codeowners_file.rb
+++ b/lib/code_ownership/private/codeowners_file.rb
@@ -111,7 +111,10 @@ module CodeOwnership
 
       sig { returns(Pathname) }
       def self.path
-        Pathname.pwd.join('.github/CODEOWNERS')
+        Pathname.pwd.join(
+          ENV.fetch('CODEOWNERS_PATH', '.github'),
+          'CODEOWNERS'
+        )
       end
 
       sig { params(files: T::Array[String]).void }

--- a/lib/code_ownership/private/codeowners_file.rb
+++ b/lib/code_ownership/private/codeowners_file.rb
@@ -112,7 +112,7 @@ module CodeOwnership
       sig { returns(Pathname) }
       def self.path
         Pathname.pwd.join(
-          ENV.fetch('CODEOWNERS_PATH', '.github'),
+          CodeOwnership.configuration.codeowners_path,
           'CODEOWNERS'
         )
       end

--- a/spec/lib/code_ownership/private/codeowners_file_spec.rb
+++ b/spec/lib/code_ownership/private/codeowners_file_spec.rb
@@ -3,10 +3,22 @@ module CodeOwnership
     describe '.path' do
       subject { described_class.path }
 
-      context 'when the environment variable is set' do
+      context 'when codeowners_path is set in the configuration' do
+        let(:configuration) do
+          Configuration.new(
+            owned_globs: [],
+            unowned_globs: [],
+            js_package_paths: [],
+            unbuilt_gems_path: nil,
+            skip_codeowners_validation: false,
+            raw_hash: {},
+            require_github_teams: false,
+            codeowners_path: path
+          )
+        end
+
         before do
-          allow(ENV).to receive(:fetch).and_call_original
-          allow(ENV).to receive(:fetch).with('CODEOWNERS_PATH', anything).and_return(path)
+          allow(CodeOwnership).to receive(:configuration).and_return(configuration)
         end
 
         context "to 'foo'" do
@@ -23,12 +35,6 @@ module CodeOwnership
           it 'uses the environment variable' do
             expect(subject).to eq(Pathname.pwd.join('CODEOWNERS'))
           end
-        end
-      end
-
-      context 'when the environment variable is not set' do
-        it 'uses the default' do
-          expect(subject).to eq(Pathname.pwd.join('.github', 'CODEOWNERS'))
         end
       end
     end

--- a/spec/lib/code_ownership/private/codeowners_file_spec.rb
+++ b/spec/lib/code_ownership/private/codeowners_file_spec.rb
@@ -1,0 +1,36 @@
+module CodeOwnership
+  RSpec.describe Private::CodeownersFile do
+    describe '.path' do
+      subject { described_class.path }
+
+      context 'when the environment variable is set' do
+        before do
+          allow(ENV).to receive(:fetch).and_call_original
+          allow(ENV).to receive(:fetch).with('CODEOWNERS_PATH', anything).and_return(path)
+        end
+
+        context "to 'foo'" do
+          let(:path) { 'foo' }
+
+          it 'uses the environment variable' do
+            expect(subject).to eq(Pathname.pwd.join('foo', 'CODEOWNERS'))
+          end
+        end
+
+        context 'to empty' do
+          let(:path) { '' }
+
+          it 'uses the environment variable' do
+            expect(subject).to eq(Pathname.pwd.join('CODEOWNERS'))
+          end
+        end
+      end
+
+      context 'when the environment variable is not set' do
+        it 'uses the default' do
+          expect(subject).to eq(Pathname.pwd.join('.github', 'CODEOWNERS'))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The current version of the gem always defaults `CODEOWNERS` to generate in `.github/CODEOWNERS`. This works well for projects that follow the same structure but doesn't work well for other structures (or other platforms). For example:

- [Github works with `CODEOWNERS` in `.github/`, `docs/` or root.](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location)
- [Gitlab works with `CODEOWNERS` in `.gitlab/`, `docs/` or root.](https://docs.gitlab.com/ee/user/project/codeowners/#codeowners-file)

This change updates the path for the file location to pull from an environment variable (`CODEOWNERS_PATH`) to use for the path. It will still default to the old behavior of using `.github/` to maintain backwards compatibility.