### PR TITLE
Support ownership for HAML files

### DIFF
--- a/lib/code_ownership/private/ownership_mappers/file_annotations.rb
+++ b/lib/code_ownership/private/ownership_mappers/file_annotations.rb
@@ -18,7 +18,7 @@ module CodeOwnership
         extend T::Sig
         include Mapper
 
-        TEAM_PATTERN = T.let(%r{\A(?:#|//) @team (?<team>.*)\Z}.freeze, Regexp)
+        TEAM_PATTERN = T.let(%r{\A(?:#|//|-#) @team (?<team>.*)\Z}.freeze, Regexp)
         DESCRIPTION = 'Annotations at the top of file'
 
         sig do

--- a/spec/lib/code_ownership/private/ownership_mappers/file_annotations_spec.rb
+++ b/spec/lib/code_ownership/private/ownership_mappers/file_annotations_spec.rb
@@ -69,19 +69,6 @@ module CodeOwnership
         it 'can find the owner of a javascript file with file annotations' do
           expect(CodeOwnership.for_file('frontend/javascripts/packages/my_package/owned_file.jsx').name).to eq 'Bar'
         end
-
-      context 'haml owned file' do
-        before do
-          write_configuration
-          write_file('config/teams/bar.yml', <<~CONTENTS)
-            name: Bar
-          CONTENTS
-
-          write_file('packs/my_pacl/owned_file.html.haml', <<~CONTENTS)
-            -# @team Bar
-          CONTENTS
-        end
-      end
       end
 
       context 'javascript owned file with brackets' do
@@ -98,6 +85,23 @@ module CodeOwnership
 
         it 'can find the owner of a javascript file with file annotations' do
           expect(CodeOwnership.for_file('frontend/javascripts/packages/my_package/[formID]/owned_file.jsx').name).to eq 'Bar'
+        end
+      end
+
+      context 'haml owned file' do
+        before do
+          write_configuration
+          write_file('config/teams/bar.yml', <<~CONTENTS)
+            name: Bar
+          CONTENTS
+
+          write_file('packs/my_pack/owned_file.html.haml', <<~CONTENTS)
+            -# @team Bar
+          CONTENTS
+        end
+
+        it 'can find the owner of a haml file with file annotations' do
+          expect(CodeOwnership.for_file('packs/my_pack/owned_file.html.haml').name).to eq 'Bar'
         end
       end
     end

--- a/spec/lib/code_ownership/private/ownership_mappers/file_annotations_spec.rb
+++ b/spec/lib/code_ownership/private/ownership_mappers/file_annotations_spec.rb
@@ -69,6 +69,19 @@ module CodeOwnership
         it 'can find the owner of a javascript file with file annotations' do
           expect(CodeOwnership.for_file('frontend/javascripts/packages/my_package/owned_file.jsx').name).to eq 'Bar'
         end
+
+      context 'haml owned file' do
+        before do
+          write_configuration
+          write_file('config/teams/bar.yml', <<~CONTENTS)
+            name: Bar
+          CONTENTS
+
+          write_file('packs/my_pacl/owned_file.html.haml', <<~CONTENTS)
+            -# @team Bar
+          CONTENTS
+        end
+      end
       end
 
       context 'javascript owned file with brackets' do
@@ -88,6 +101,8 @@ module CodeOwnership
         end
       end
     end
+
+
 
     describe '.remove_file_annotation!' do
       subject(:remove_file_annotation) do


### PR DESCRIPTION
This PR adds [HAML comment syntax](https://haml.info/docs/yardoc/file.REFERENCE.html#haml-comments--) to the `TEAM_PATTERN` Regex, along with corresponding tests. 