### PR TITLE
feat: add concept of unowned globs to team configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Gemfile.lock
 .rspec_status
 
 .DS_Store
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ Gemfile.lock
 .rspec_status
 
 .DS_Store
-.idea/

--- a/lib/code_ownership/private/ownership_mappers/team_globs.rb
+++ b/lib/code_ownership/private/ownership_mappers/team_globs.rb
@@ -72,7 +72,7 @@ module CodeOwnership
             # Remove anything that is unowned
             TeamPlugins::Ownership.for(team).unowned_globs.each do |glob|
               Dir.glob(glob).each do |filename|
-                T.must(mapped_files.delete(filename))
+                mapped_files.reject! { |key, value| key == filename && value.any? { |context| context.team == team } }
               end
             end
           end

--- a/lib/code_ownership/private/team_plugins/ownership.rb
+++ b/lib/code_ownership/private/team_plugins/ownership.rb
@@ -11,6 +11,11 @@ module CodeOwnership
         def owned_globs
           @team.raw_hash['owned_globs'] || []
         end
+
+        sig { returns(T::Array[String]) }
+        def unowned_globs
+          @team.raw_hash['unowned_globs'] || []
+        end
       end
     end
   end


### PR DESCRIPTION
This adds the ability to specify `unowned_globs` for a team. The primary use case of this is to allow more granularity in how ownership globs are defined.

Suppose you want Team A to own everything that has a folder named `foo` in the path, so you would define a glob like: `**/foo/**/*` but at the same time, you want Team B to own everything in a specific folder, regardless if it has a `foo` folder in it or not. So you would define a glob like: `shared/**/*`, but if it actually has a `foo` folder in it, then the validation would complain that you cannot have overlapping ownership between teams.

With this, you can now specify that Team does not own `shared/**/foo/*` and everyone is happy.

To the best of my knowledge, nothing needs to change in the `CODEOWNERS` generation, since it already puts less specific globs at the top and more specific ones at the bottom. So in effect, the above ownership rules will be enforced just fine. 

This fixes https://github.com/rubyatscale/code_ownership/issues/116