### PR TITLE
Fix JSON spec

### DIFF
--- a/spec/lib/code_ownership/private/ownership_mappers/js_package_ownership_spec.rb
+++ b/spec/lib/code_ownership/private/ownership_mappers/js_package_ownership_spec.rb
@@ -17,7 +17,7 @@ module CodeOwnership
         it 'lets the user know the their package JSON is invalid' do
           expect { CodeOwnership.validate! }.to raise_error do |e|
             expect(e).to be_a CodeOwnership::InvalidCodeOwnershipConfigurationError
-            expect(e.message).to match(/JSON::ParserError.*?unexpected token/)
+            expect(e.message).to match(/JSON::ParserError/)
             expect(e.message).to include 'frontend/javascripts/my_package/package.json has invalid JSON, so code ownership cannot be determined.'
             expect(e.message).to include 'Please either make the JSON in that file valid or specify `js_package_paths` in config/code_ownership.yml.'
           end


### PR DESCRIPTION
We were checking for specific text in the JSONParseError, but when json was updated, the message changed. We really only care that there was a JSON parse error so we're shortening the string we're checking. This change will make it so we don't run into this error again in future version updates.