### PR TITLE
Ignore ENOENT when reading file annotations

### DIFF
--- a/spec/lib/code_ownership/private/ownership_mappers/file_annotations_spec.rb
+++ b/spec/lib/code_ownership/private/ownership_mappers/file_annotations_spec.rb
@@ -37,6 +37,28 @@ module CodeOwnership
     end
 
     describe '.for_file' do
+      context 'path is a directory' do
+        it 'returns nil' do
+          write_configuration
+          write_file('config/teams/bar.yml', <<~CONTENTS)
+            name: Bar
+          CONTENTS
+
+          expect(CodeOwnership.for_file('config/teams')).to be_nil
+        end
+      end
+
+      context 'path does not exist' do
+        it 'returns nil' do
+          write_configuration
+          write_file('config/teams/bar.yml', <<~CONTENTS)
+            name: Bar
+          CONTENTS
+
+          expect(CodeOwnership.for_file('config/teams/foo.yml')).to be_nil
+        end
+      end
+
       context 'ruby owned file' do
         before do
           write_configuration


### PR DESCRIPTION
Errno::ENOENT is occuring intermittently for some users. This is happening even when the file seems to exist at the time

Since we were already returning quietly if a file did not exist, just try to read the file and rescue exceptions, returning silently.

Fixes #98