### PR TITLE
Update codeowners-rs  and new for_file --verbose option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,8 +200,8 @@ dependencies = [
 
 [[package]]
 name = "codeowners"
-version = "0.2.7"
-source = "git+https://github.com/rubyatscale/codeowners-rs.git?tag=v0.2.7#ca456be254a81e9a84a87e605c00da66e6c644ec"
+version = "0.2.14"
+source = "git+https://github.com/rubyatscale/codeowners-rs.git?tag=v0.2.14#55832fc2bc34d961571fdf14e1a02761590aa2be"
 dependencies = [
  "clap",
  "clap_derive",

--- a/ext/code_ownership/Cargo.toml
+++ b/ext/code_ownership/Cargo.toml
@@ -17,7 +17,7 @@ rb-sys = { version = "0.9.111", features = [
 magnus = { version = "0.7.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_magnus = "0.9.0"
-codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.7" }
+codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.14" }
 
 [dev-dependencies]
 rb-sys = { version = "0.9.117", features = [

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -11,6 +11,7 @@ require 'code_ownership/version'
 require 'code_ownership/private/file_path_finder'
 require 'code_ownership/private/file_path_team_cache'
 require 'code_ownership/private/team_finder'
+require 'code_ownership/private/for_file_output_builder'
 require 'code_ownership/cli'
 
 begin

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -44,6 +44,11 @@ module CodeOwnership
     Private::TeamFinder.for_file(file)
   end
 
+  sig { params(file: String).returns(T.nilable(T::Hash[Symbol, String])) }
+  def for_file_verbose(file)
+    ::RustCodeOwners.for_file(file)
+  end
+
   sig { params(team: T.any(CodeTeams::Team, String)).returns(T::Array[String]) }
   def for_team(team)
     team = T.must(CodeTeams.find(team)) if team.is_a?(String)

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -111,54 +111,7 @@ module CodeOwnership
         raise "Please pass in one file. Use `#{EXECUTABLE} for_file --help` for more info"
       end
 
-      if options[:verbose]
-        for_file_verbose(file: files.first, json: options[:json])
-      else
-        for_file_terse(file: files.first, json: options[:json])
-      end
-    end
-
-    def self.for_file_terse(file:, json:)
-      team = CodeOwnership.for_file(file)
-
-      team_name = team&.name || 'Unowned'
-      team_yml = team&.config_yml || 'Unowned'
-
-      if json
-        json_output = {
-          team_name: team_name,
-          team_yml: team_yml
-        }
-
-        puts json_output.to_json
-      else
-        puts <<~MSG
-          Team: #{team_name}
-          Team YML: #{team_yml}
-        MSG
-      end
-    end
-
-    def self.for_file_verbose(file:, json:)
-      verbose = CodeOwnership.for_file_verbose(file) || {team_name: 'Unowned', team_config_yml: 'Unowned', reasons: []}
-
-      if json
-        json = {
-          team_name: verbose[:team_name],
-          team_yml: verbose[:team_config_yml],
-          reasons: verbose[:reasons]
-        }
-
-        puts json.to_json
-      else
-        messages = ["Team: #{verbose[:team_name]}", "Team YML: #{verbose[:team_config_yml]}"]
-        if verbose[:reasons].any?
-          messages << "Reasons:\n- #{verbose[:reasons].join("\n-")}"
-        end
-        messages.last << "\n"
-
-        puts messages.join("\n")
-      end
+      puts CodeOwnership::Private::ForFileOutputBuilder.build(file_path: files.first, json: !!options[:json], verbose: !!options[:verbose])
     end
 
     def self.for_team(argv)

--- a/lib/code_ownership/private/for_file_output_builder.rb
+++ b/lib/code_ownership/private/for_file_output_builder.rb
@@ -47,7 +47,7 @@ module CodeOwnership
         {
           team_name: result[:team_name],
           team_yml: result[:team_config_yml],
-          reasons: result[:reasons]
+          description: result[:reasons]
         }
       end
 
@@ -68,15 +68,15 @@ module CodeOwnership
       sig { params(result_hash: T::Hash[Symbol, T.untyped]).returns(String) }
       def build_message_for(result_hash)
         messages = ["Team: #{result_hash[:team_name]}", "Team YML: #{result_hash[:team_yml]}"]
-        reasons_list = T.let(Array(result_hash[:reasons]), T::Array[String])
-        messages << build_reasons_message(reasons_list) unless reasons_list.empty?
+        description_list = T.let(Array(result_hash[:description]), T::Array[String])
+        messages << build_description_message(description_list) unless description_list.empty?
         messages.last << "\n"
         messages.join("\n")
       end
 
       sig { params(reasons: T::Array[String]).returns(String) }
-      def build_reasons_message(reasons)
-        "Reasons:\n- #{reasons.join("\n-")}"
+      def build_description_message(reasons)
+        "Description:\n- #{reasons.join("\n-")}"
       end
     end
   end

--- a/lib/code_ownership/private/for_file_output_builder.rb
+++ b/lib/code_ownership/private/for_file_output_builder.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+module CodeOwnership
+  module Private
+    class ForFileOutputBuilder
+      extend T::Sig
+      private_class_method :new
+
+      sig { params(file_path: String, json: T::Boolean, verbose: T::Boolean).void }
+      def initialize(file_path:, json:, verbose:)
+        @file_path = file_path
+        @json = json
+        @verbose = verbose
+      end
+
+      sig { params(file_path: String, json: T::Boolean, verbose: T::Boolean).returns(String) }
+      def self.build(file_path:, json:, verbose:)
+        new(file_path: file_path, json: json, verbose: verbose).build
+      end
+
+      UNOWNED_OUTPUT = T.let(
+        {
+          team_name: 'Unowned',
+          team_yml: 'Unowned'
+        },
+        T::Hash[Symbol, T.untyped]
+      )
+
+      sig { returns(String) }
+      def build
+        result_hash = @verbose ? build_verbose : build_terse
+
+        return result_hash.to_json if @json
+
+        build_message_for(result_hash)
+      end
+
+      private
+
+      sig { returns(T::Hash[Symbol, T.untyped]) }
+      def build_verbose
+        result = CodeOwnership.for_file_verbose(@file_path)
+        return UNOWNED_OUTPUT if result.nil?
+
+        {
+          team_name: result[:team_name],
+          team_yml: result[:team_config_yml],
+          reasons: result[:reasons]
+        }
+      end
+
+      sig { returns(T::Hash[Symbol, T.untyped]) }
+      def build_terse
+        team = CodeOwnership.for_file(@file_path)
+
+        if team.nil?
+          UNOWNED_OUTPUT
+        else
+          {
+            team_name: team.name,
+            team_yml: team.config_yml
+          }
+        end
+      end
+
+      sig { params(result_hash: T::Hash[Symbol, T.untyped]).returns(String) }
+      def build_message_for(result_hash)
+        messages = ["Team: #{result_hash[:team_name]}", "Team YML: #{result_hash[:team_yml]}"]
+        reasons_list = T.let(Array(result_hash[:reasons]), T::Array[String])
+        messages << build_reasons_message(reasons_list) unless reasons_list.empty?
+        messages.last << "\n"
+        messages.join("\n")
+      end
+
+      sig { params(reasons: T::Array[String]).returns(String) }
+      def build_reasons_message(reasons)
+        "Reasons:\n- #{reasons.join("\n-")}"
+      end
+    end
+  end
+end

--- a/lib/code_ownership/version.rb
+++ b/lib/code_ownership/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CodeOwnership
-  VERSION = '2.0.0-1'
+  VERSION = '2.0.0-2'
 end

--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -176,6 +176,20 @@ RSpec.describe CodeOwnership::Cli do
         end
       end
 
+      context 'when run with --verbose' do
+        let(:argv) { ['for_file', 'app/services/my_file.rb', '--verbose'] }
+
+        it 'outputs the team info in human readable format' do
+          expect(CodeOwnership::Cli).to receive(:puts).with(<<~MSG)
+            Team: My Team
+            Team YML: config/teams/my_team.yml
+            Reasons:
+            - Owner specified in Team YML as an owned_glob `app/**/*.rb`
+          MSG
+          subject
+        end
+      end
+
       context 'when run with no files' do
         let(:argv) { ['for_file'] }
 
@@ -204,6 +218,19 @@ RSpec.describe CodeOwnership::Cli do
           }
           expect(CodeOwnership::Cli).to receive(:puts).with(json.to_json)
           subject
+        end
+
+        context 'when run with multiple files' do
+          let(:argv) { ['for_file', '--json', '--verbose', 'app/services/my_file.rb'] }
+          it 'outputs JSONified information to the console' do
+            json = {
+              team_name: 'My Team',
+              team_yml: 'config/teams/my_team.yml',
+              reasons: ['Owner specified in Team YML as an owned_glob `app/**/*.rb`']
+            }
+            expect(CodeOwnership::Cli).to receive(:puts).with(json.to_json)
+            subject
+          end  
         end
       end
 
@@ -234,6 +261,19 @@ RSpec.describe CodeOwnership::Cli do
           Team YML: Unowned
         MSG
         subject
+      end
+
+      context 'when run with --verbose' do
+        let(:argv) { ['for_file', 'app/services/unowned.rb', '--verbose'] }
+
+        it 'prints Unowned' do
+          allow(CodeOwnership).to receive(:for_file_verbose).and_return(nil)
+          expect(CodeOwnership::Cli).to receive(:puts).with(<<~MSG)
+            Team: Unowned
+            Team YML: Unowned
+          MSG
+          subject
+        end
       end
     end
 

--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe CodeOwnership::Cli do
           expect(CodeOwnership::Cli).to receive(:puts).with(<<~MSG)
             Team: My Team
             Team YML: config/teams/my_team.yml
-            Reasons:
+            Description:
             - Owner specified in Team YML as an owned_glob `app/**/*.rb`
           MSG
           subject
@@ -220,17 +220,17 @@ RSpec.describe CodeOwnership::Cli do
           subject
         end
 
-        context 'when run with multiple files' do
+        context 'when run with --verbose' do
           let(:argv) { ['for_file', '--json', '--verbose', 'app/services/my_file.rb'] }
           it 'outputs JSONified information to the console' do
             json = {
               team_name: 'My Team',
               team_yml: 'config/teams/my_team.yml',
-              reasons: ['Owner specified in Team YML as an owned_glob `app/**/*.rb`']
+              description: ['Owner specified in Team YML as an owned_glob `app/**/*.rb`']
             }
             expect(CodeOwnership::Cli).to receive(:puts).with(json.to_json)
             subject
-          end  
+          end
         end
       end
 


### PR DESCRIPTION
Updates codeowners-rs to version 0.2.14, which includes:
---
- support for ERB file annotations
- file annotation can contain a `:` after team. Example: `# team: Foo`
- unstaged files are ignored

New verbose flag
---
`bin/codeownership for_file --verbose path/to/file.rb` prints out the reason for ownership

Example:
```sh
bin/codeowners for-file my/file.rb
Team: Foo
Github Team: @foo
Team YML: config/teams/foo.yml
Description:
- Owner annotation at the top of the file

```