### PR TITLE
Teams for file paths

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,130 +1,184 @@
 ---
-    name: CD
-    
-    on:
-      workflow_dispatch:
-      push:
-        tags: ["v*"]
-    
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    
-    jobs:
-      ci-data:
-        runs-on: ubuntu-latest
-        outputs:
-          result: ${{ steps.fetch.outputs.result }}
-        steps:
-          - id: fetch
-            uses: oxidize-rb/actions/fetch-ci-data@v1
-            with:
-              supported-ruby-platforms: |
-                # Excluding:
-                # `arm-linux`: Cranelift doesn't support 32-bit architectures
-                # `x64-mingw32`: `x64-mingw-ucrt` should be used for Ruby 3.1+ (https://github.com/rake-compiler/rake-compiler-dock?tab=readme-ov-file#windows)
-                # 3.0 is deprecated as stable ruby version according to:
-                #  https://github.com/oxidize-rb/actions/blob/main/fetch-ci-data/evaluate.rb#L54
-                exclude: [arm-linux, x64-mingw32]
-              stable-ruby-versions: |
-                exclude: [head]
-    
-      build:
-        name: Build native gems
-        needs: ci-data
-        runs-on: ubuntu-latest
-        strategy:
-          fail-fast: false
-          matrix:
-            ruby-platform: ${{ fromJSON(needs.ci-data.outputs.result).supported-ruby-platforms }}
-        steps:
-          - uses: actions/checkout@v4
-    
-          - uses: ruby/setup-ruby@v1
-            with:
-              ruby-version: "3.4"
-    
-          - uses: oxidize-rb/actions/cross-gem@v1
-            id: cross-gem
-            with:
-              platform: ${{ matrix.ruby-platform }}
-              ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ',') }}
-    
-          - uses: actions/upload-artifact@v4
-            with:
-              name: cross-gem-${{ matrix.ruby-platform }}
-              path: pkg/*-${{ matrix.ruby-platform }}.gem
-              if-no-files-found: error
-    
-          - name: Smoke gem install
-            if: matrix.ruby-platform == 'ignore-for-now-x86_64-linux' # GitHub actions architecture
-            run: |
-              gem install pkg/fast_code_owners-*.gem --verbose
-              script="puts FastCodeOwners::VERSION"
-              ruby -rfast_code_owners -e "$script" | grep 0.1.0
-              echo "✅ Successfully gem installed"
-    
-      release:
-        name: Release
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v4
-    
-          - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
-            with:
-              ruby-version: "3.4"
-              bundler-cache: true
-              cargo-cache: true
-              cache-version: v1
-    
-          - uses: actions/download-artifact@v4
-            with:
-              pattern: cross-gem-*
-              merge-multiple: true
-              path: pkg/
-    
-          - name: Package source gem
-            run: bundle exec rake pkg:ruby
-    
-          - name: Ensure version matches the tag
-            run: |
-              GEM_VERSION=$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+[-0-9]*" lib/code_ownership/version.rb | head -n 1)
-              if [ "v$GEM_VERSION" != "${{ github.ref_name }}" ]; then
-                echo "Gem version does not match tag"
-                echo "  v$GEM_VERSION != ${{ github.ref_name }}"
-                exit 1
-              fi
-    
-          - name: Push Gem
-            working-directory: pkg/
-            env:
-              GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-            run: |
-              mkdir -p $HOME/.gem
-              touch $HOME/.gem/credentials
-              chmod 0600 $HOME/.gem/credentials
-              printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-              ls -l
-              for i in *.gem; do
-                if [ -f "$i" ]; then
-                  if ! gem push "$i" >push.out; then
-                    gemerr=$?
-                    sed 's/^/::error:: /' push.out
-                    if ! grep -q "Repushing of gem" push.out; then
-                      exit $gemerr
-                    fi
+  name: CD
+  
+  on:
+    workflow_call:
+  
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+  
+  jobs:
+    ci-data:
+      runs-on: ubuntu-latest
+      outputs:
+        result: ${{ steps.fetch.outputs.result }}
+      steps:
+        - id: fetch
+          uses: oxidize-rb/actions/fetch-ci-data@v1
+          with:
+            supported-ruby-platforms: |
+              # Excluding:
+              # `arm-linux`: Cranelift doesn't support 32-bit architectures
+              # `x64-mingw32`: `x64-mingw-ucrt` should be used for Ruby 3.1+ (https://github.com/rake-compiler/rake-compiler-dock?tab=readme-ov-file#windows)
+              # `x64-mingw-ucrt`: Rust target not available in rake-compiler-dock
+              # `aarch64-linux-musl`: Rust target not available in rake-compiler-dock
+              # 3.0 is deprecated as stable ruby version according to:
+              #  https://github.com/oxidize-rb/actions/blob/main/fetch-ci-data/evaluate.rb#L54
+              exclude: [arm-linux, x64-mingw32, x64-mingw-ucrt, aarch64-linux-musl]
+            stable-ruby-versions: |
+              exclude: [head]
+  
+    build:
+      name: Build native gems
+      needs: ci-data
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          ruby-platform: ${{ fromJSON(needs.ci-data.outputs.result).supported-ruby-platforms }}
+      steps:
+        - uses: actions/checkout@v4
+  
+        - uses: ruby/setup-ruby@v1
+          with:
+            ruby-version: "3.4"
+
+        - uses: oxidize-rb/actions/cross-gem@v1
+          id: cross-gem
+          with:
+            platform: ${{ matrix.ruby-platform }}
+            ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ',') }}
+            cache-save-always: false
+            cargo-cache-clean: false  # Add this to disable cargo-cache usage
+          env:
+            # Add a unique identifier to prevent cache conflicts
+            ACTIONS_CACHE_KEY_SUFFIX: "-${{ matrix.ruby-platform }}-${{ github.run_id }}"
+  
+        - uses: actions/upload-artifact@v4
+          with:
+            name: cross-gem-${{ matrix.ruby-platform }}
+            path: pkg/*-${{ matrix.ruby-platform }}.gem
+            if-no-files-found: error
+            retention-days: 30  # Keep artifacts for 30 days
+  
+        - name: Smoke test gem install
+          if: matrix.ruby-platform == 'x86_64-linux'  # Enable for Linux x64
+          run: |
+            # Install the platform-specific gem
+            gem install pkg/code_ownership-*-${{ matrix.ruby-platform }}.gem --verbose
+            
+            # Test that it works
+            ruby -e "require 'code_ownership'; puts 'Version: ' + CodeOwnership::VERSION"
+            
+            # Run a simple functionality test
+            ruby -e "require 'code_ownership'; CodeOwnership.file_owner_team_names('lib/code_ownership.rb')" || true
+            
+            echo "✅ Successfully tested ${{ matrix.ruby-platform }} gem"
+  
+    release:
+      name: Release
+      needs: build
+      runs-on: ubuntu-latest
+      permissions:
+        contents: write  # Required for creating releases
+      steps:
+        - uses: actions/checkout@v4
+  
+        - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+          with:
+            ruby-version: "3.4"
+            bundler-cache: true
+            cargo-cache: false
+  
+        - uses: actions/download-artifact@v4
+          with:
+            pattern: cross-gem-*
+            merge-multiple: true
+            path: pkg/
+  
+        - name: Package source gem
+          run: bundle exec rake pkg:ruby
+  
+        - name: Push Gem
+          id: push-gem
+          working-directory: pkg/
+          env:
+            GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          run: |
+            set -e  # Exit on error
+            
+            # Setup credentials
+            mkdir -p $HOME/.gem
+            touch $HOME/.gem/credentials
+            chmod 0600 $HOME/.gem/credentials
+            printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+            
+            # List all gems to be pushed
+            echo "📦 Gems to be pushed:"
+            ls -la *.gem
+            
+            # Extract version from the Ruby version file
+            GEM_VERSION=$(ruby -r ../lib/code_ownership/version.rb -e "puts CodeOwnership::VERSION")
+            echo "gem_version=${GEM_VERSION}" >> $GITHUB_OUTPUT
+            echo "🏷️ Detected gem version: ${GEM_VERSION}"
+            
+            # Track results
+            NEW_VERSION=false
+            PUSHED_GEMS=()
+            SKIPPED_GEMS=()
+            
+            for i in *.gem; do
+              if [ -f "$i" ]; then
+                echo "⏳ Attempting to push $i..."
+                if ! gem push "$i" >push.out 2>&1; then
+                  gemerr=$?
+                  if grep -q "Repushing of gem" push.out; then
+                    echo "⏭️ Gem $i already exists on RubyGems, skipping..."
+                    SKIPPED_GEMS+=("$i")
+                  else
+                    echo "❌ Failed to push $i:"
+                    cat push.out
+                    exit $gemerr
                   fi
+                else
+                  echo "✅ Successfully pushed $i"
+                  PUSHED_GEMS+=("$i")
+                  NEW_VERSION=true
                 fi
-              done
-    
-          - name: Create GitHub release
-            uses: ncipollo/release-action@v1
-            with:
-              allowUpdates: true
-              generateReleaseNotes: true
-              draft: true
-              omitBodyDuringUpdate: true
-              omitNameDuringUpdate: true
-              omitPrereleaseDuringUpdate: true
-              skipIfReleaseExists: true
+              fi
+            done
+            
+            # Summary
+            echo "📊 Push Summary:"
+            echo "  - Pushed: ${#PUSHED_GEMS[@]} gems"
+            echo "  - Skipped: ${#SKIPPED_GEMS[@]} gems"
+            
+            # Set outputs
+            echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+            echo "pushed_count=${#PUSHED_GEMS[@]}" >> $GITHUB_OUTPUT
+            echo "skipped_count=${#SKIPPED_GEMS[@]}" >> $GITHUB_OUTPUT
+  
+        - name: Create GitHub Release
+          if: ${{ steps.push-gem.outputs.new_version == 'true' }}
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            # Create release with more detailed information
+            RELEASE_NOTES="## CodeOwnership v${{ steps.push-gem.outputs.gem_version }}
+
+            ### 📦 Published Gems
+            - Source gem: code_ownership-${{ steps.push-gem.outputs.gem_version }}.gem
+            - Platform gems: Published for all supported platforms
+            
+            ### 🎯 Supported Platforms
+            $(ls pkg/*.gem | grep -E '\-(x86|arm|aarch)' | sed 's/.*-\([^-]*\)\.gem/- \1/')
+            
+            ---
+            "
+            
+            gh release create "v${{ steps.push-gem.outputs.gem_version }}" \
+              --title "v${{ steps.push-gem.outputs.gem_version }}" \
+              --notes "$RELEASE_NOTES" \
+              --generate-notes \
+              pkg/*.gem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,31 +16,30 @@ jobs:
         uses: oxidize-rb/actions/fetch-ci-data@v1
         with:
           stable-ruby-versions: |
-              # See https://github.com/bytecodealliance/wasmtime-rb/issues/286
-              # for details.
-              exclude: [head]
+            # See https://github.com/bytecodealliance/wasmtime-rb/issues/286
+            # for details.
+            exclude: [head]
   rspec:
-      runs-on: ${{ matrix.os }}
-      needs: ci-data
-      strategy:
-        fail-fast: false
-        matrix:
-          os: ["ubuntu-latest", "macos-latest"]
-          ruby: ${{ fromJSON(needs.ci-data.outputs.result).stable-ruby-versions }}
-      steps:
-        - uses: actions/checkout@v4
-        - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
-          with:
-            ruby-version: ${{ matrix.ruby }}
-            bundler-cache: true
-            cargo-cache: true
-            cache-version: v5
-  
-        - name: Compile rust ext
-          run: bundle exec rake compile:release
-  
-        - name: Run ruby tests
-          run: bundle exec rake spec
+    runs-on: ${{ matrix.os }}
+    needs: ci-data
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        ruby: ${{ fromJSON(needs.ci-data.outputs.result).stable-ruby-versions }}
+        rust: ["stable"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          rustup-toolchain: ${{ matrix.rust }}
+          bundler-cache: true
+          cargo-cache: false
+      - name: Run ruby tests
+        run: bundle exec rake
+      - name: Compile rust ext
+        run: bundle exec rake compile:release
   static_type_check:
     name: "Type Check"
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -200,8 +200,7 @@ dependencies = [
 
 [[package]]
 name = "codeowners"
-version = "0.2.14"
-source = "git+https://github.com/rubyatscale/codeowners-rs.git?tag=v0.2.14#55832fc2bc34d961571fdf14e1a02761590aa2be"
+version = "0.2.15"
 dependencies = [
  "clap",
  "clap_derive",
@@ -296,7 +295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -349,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -635,9 +634,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -645,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -758,7 +757,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -810,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -907,15 +906,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1061,11 +1060,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1079,15 +1078,6 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
 [[package]]
 name = "codeowners"
 version = "0.2.17"
+source = "git+https://github.com/rubyatscale/codeowners-rs.git?tag=v0.2.17#cc9a3878918a795f982421263c1dc9e4f9cb860b"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,8 +200,8 @@ dependencies = [
 
 [[package]]
 name = "codeowners"
-version = "0.2.15"
-source = "git+https://github.com/rubyatscale/codeowners-rs.git?tag=v0.2.15#37027e3d4402d17bf0f623dc88c93868ef874611"
+version = "0.2.16"
+source = "git+https://github.com/rubyatscale/codeowners-rs.git?tag=v0.2.16#9cee8f0e3245dcc6ecf52f4eed6d89408a3665af"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
 [[package]]
 name = "codeowners"
 version = "0.2.15"
+source = "git+https://github.com/rubyatscale/codeowners-rs.git?tag=v0.2.15#37027e3d4402d17bf0f623dc88c93868ef874611"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +21,68 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "bindgen"
@@ -20,7 +93,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -28,7 +101,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -36,6 +109,16 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "cexpr"
@@ -64,9 +147,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "code_ownership"
 version = "0.1.0"
 dependencies = [
+ "codeowners",
  "magnus",
  "rb-sys",
  "rb-sys-env 0.2.2",
@@ -75,16 +199,224 @@ dependencies = [
 ]
 
 [[package]]
+name = "codeowners"
+version = "0.2.17"
+dependencies = [
+ "clap",
+ "clap_derive",
+ "crossbeam-channel",
+ "enum_dispatch",
+ "error-stack",
+ "fast-glob",
+ "glob",
+ "ignore",
+ "itertools 0.14.0",
+ "lazy_static",
+ "memoize",
+ "path-clean",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "error-stack"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe413319145d1063f080f27556fd30b1d70b01e2ba10c2a6e40d4be982ffc5d1"
+dependencies = [
+ "anyhow",
+ "rustc_version",
+]
+
+[[package]]
+name = "fast-glob"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d26eec0ae9682c457cb0f85de67ad417b716ae852736a5d94c2ad6e92a997c9"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.9",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -94,6 +426,21 @@ checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -120,7 +467,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -143,7 +511,16 @@ checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -151,6 +528,29 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8d1d5792299bab3f8b5d88d1b7a7cb50ad7ef039a8c4d45a6b84880a6526276"
+dependencies = [
+ "lazy_static",
+ "lru",
+ "memoize-inner",
+]
+
+[[package]]
+name = "memoize-inner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd8f89255d8ff313afabed9a3c83ef0993cc056679dfd001f5111a026f876f7"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -169,6 +569,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +624,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -207,7 +673,7 @@ dependencies = [
  "quote",
  "regex",
  "shell-words",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -230,8 +696,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -242,8 +717,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -256,6 +737,49 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "seq-macro"
@@ -280,7 +804,19 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -295,6 +831,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +863,29 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -324,10 +905,188 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
 
 [[package]]
 name = "windows-targets"
@@ -335,14 +1094,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -352,10 +1128,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -364,10 +1152,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -376,10 +1176,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -388,7 +1200,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,68 +10,6 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "anstream"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
-
-[[package]]
-name = "anyhow"
-version = "1.0.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "bindgen"
@@ -93,7 +20,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -101,7 +28,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.101",
+ "syn",
 ]
 
 [[package]]
@@ -109,16 +36,6 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
-name = "bstr"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "cexpr"
@@ -147,50 +64,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
 name = "code_ownership"
 version = "0.1.0"
 dependencies = [
- "codeowners",
  "magnus",
  "rb-sys",
  "rb-sys-env 0.2.2",
@@ -199,225 +75,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "codeowners"
-version = "0.2.16"
-source = "git+https://github.com/rubyatscale/codeowners-rs.git?tag=v0.2.16#9cee8f0e3245dcc6ecf52f4eed6d89408a3665af"
-dependencies = [
- "clap",
- "clap_derive",
- "crossbeam-channel",
- "enum_dispatch",
- "error-stack",
- "fast-glob",
- "glob",
- "ignore",
- "itertools 0.14.0",
- "lazy_static",
- "memoize",
- "path-clean",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "serde_yaml",
- "tempfile",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "enum_dispatch"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "error-stack"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe413319145d1063f080f27556fd30b1d70b01e2ba10c2a6e40d4be982ffc5d1"
-dependencies = [
- "anyhow",
- "rustc_version",
-]
-
-[[package]]
-name = "fast-glob"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d26eec0ae9682c457cb0f85de67ad417b716ae852736a5d94c2ad6e92a997c9"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "globset"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "ignore"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata 0.4.9",
- "same-file",
- "walkdir",
- "winapi-util",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
-dependencies = [
- "equivalent",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -427,21 +94,6 @@ checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -468,28 +120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
-
-[[package]]
-name = "log"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "lru"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-dependencies = [
- "hashbrown 0.12.3",
+ "windows-targets",
 ]
 
 [[package]]
@@ -512,16 +143,7 @@ checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
+ "syn",
 ]
 
 [[package]]
@@ -529,29 +151,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memoize"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d1d5792299bab3f8b5d88d1b7a7cb50ad7ef039a8c4d45a6b84880a6526276"
-dependencies = [
- "lazy_static",
- "lru",
- "memoize-inner",
-]
-
-[[package]]
-name = "memoize-inner"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd8f89255d8ff313afabed9a3c83ef0993cc056679dfd001f5111a026f876f7"
-dependencies = [
- "lazy_static",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -570,46 +169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "path-clean"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,32 +184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -674,7 +207,7 @@ dependencies = [
  "quote",
  "regex",
  "shell-words",
- "syn 2.0.101",
+ "syn",
 ]
 
 [[package]]
@@ -697,17 +230,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -718,14 +242,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -738,49 +256,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "seq-macro"
@@ -805,19 +280,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.143"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
+ "syn",
 ]
 
 [[package]]
@@ -832,28 +295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,29 +305,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -906,188 +324,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tempfile"
-version = "3.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
-dependencies = [
- "fastrand",
- "getrandom 0.3.3",
- "once_cell",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
-dependencies = [
- "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
-]
 
 [[package]]
 name = "windows-targets"
@@ -1095,31 +335,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1129,22 +352,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1153,22 +364,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1177,22 +376,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1201,28 +388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]

--- a/ext/code_ownership/Cargo.toml
+++ b/ext/code_ownership/Cargo.toml
@@ -17,7 +17,7 @@ rb-sys = { version = "0.9.111", features = [
 magnus = { version = "0.7.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_magnus = "0.9.0"
-codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.15" }
+codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.16" }
 
 [dev-dependencies]
 rb-sys = { version = "0.9.117", features = [

--- a/ext/code_ownership/Cargo.toml
+++ b/ext/code_ownership/Cargo.toml
@@ -10,21 +10,22 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rb-sys = { version = "0.9.111", features = [
-  "bindgen-rbimpls",
-  "bindgen-deprecated-types",
-  "stable-api-compiled-fallback",
+    "bindgen-rbimpls",
+    "bindgen-deprecated-types",
+    "stable-api-compiled-fallback",
 ] }
 magnus = { version = "0.7.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_magnus = "0.9.0"
-codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.17" }
+# codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.17" }
+codeowners = { path = "../../../codeowners-rs" }
 
 [dev-dependencies]
 rb-sys = { version = "0.9.117", features = [
-  "link-ruby",
-  "bindgen-rbimpls",
-  "bindgen-deprecated-types",
-  "stable-api-compiled-fallback",
+    "link-ruby",
+    "bindgen-rbimpls",
+    "bindgen-deprecated-types",
+    "stable-api-compiled-fallback",
 ] }
 
 [build-dependencies]

--- a/ext/code_ownership/Cargo.toml
+++ b/ext/code_ownership/Cargo.toml
@@ -17,8 +17,7 @@ rb-sys = { version = "0.9.111", features = [
 magnus = { version = "0.7.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_magnus = "0.9.0"
-# codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.14" }
-codeowners = { path = "../../../codeowners-rs" }
+codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.15" }
 
 [dev-dependencies]
 rb-sys = { version = "0.9.117", features = [

--- a/ext/code_ownership/Cargo.toml
+++ b/ext/code_ownership/Cargo.toml
@@ -17,8 +17,7 @@ rb-sys = { version = "0.9.111", features = [
 magnus = { version = "0.7.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_magnus = "0.9.0"
-# codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.17" }
-codeowners = { path = "../../../codeowners-rs" }
+codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.17" }
 
 [dev-dependencies]
 rb-sys = { version = "0.9.117", features = [

--- a/ext/code_ownership/Cargo.toml
+++ b/ext/code_ownership/Cargo.toml
@@ -17,7 +17,8 @@ rb-sys = { version = "0.9.111", features = [
 magnus = { version = "0.7.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_magnus = "0.9.0"
-codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.14" }
+# codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.14" }
+codeowners = { path = "../../../codeowners-rs" }
 
 [dev-dependencies]
 rb-sys = { version = "0.9.117", features = [

--- a/ext/code_ownership/Cargo.toml
+++ b/ext/code_ownership/Cargo.toml
@@ -17,7 +17,7 @@ rb-sys = { version = "0.9.111", features = [
 magnus = { version = "0.7.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_magnus = "0.9.0"
-codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.16" }
+codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.2.17" }
 
 [dev-dependencies]
 rb-sys = { version = "0.9.117", features = [

--- a/ext/code_ownership/src/lib.rs
+++ b/ext/code_ownership/src/lib.rs
@@ -18,7 +18,7 @@ fn for_team(team_name: String) -> Result<Value, Error> {
     validate_result(&team)
 }
 
-fn team_names_for_files(file_paths: Vec<String>) -> Result<Value, Error> {
+fn teams_for_files(file_paths: Vec<String>) -> Result<Value, Error> {
     let run_config = build_run_config();
     let path_teams = runner::teams_for_files_from_codeowners(&run_config, &file_paths);
     match path_teams {
@@ -126,7 +126,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     module.define_singleton_method("validate", function!(validate, 0))?;
     module.define_singleton_method("for_team", function!(for_team, 1))?;
     module.define_singleton_method("version", function!(version, 0))?;
-    module.define_singleton_method("team_names_for_files", function!(team_names_for_files, 1))?;
+    module.define_singleton_method("teams_for_files", function!(teams_for_files, 1))?;
 
     Ok(())
 }

--- a/ext/code_ownership/src/lib.rs
+++ b/ext/code_ownership/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf};
+use std::{collections::HashMap, env, path::PathBuf};
 
 use codeowners::runner::{self, RunConfig};
 use magnus::{Error, Ruby, Value, function, prelude::*};
@@ -16,6 +16,30 @@ fn for_team(team_name: String) -> Result<Value, Error> {
     let run_config = build_run_config();
     let team = runner::for_team(&run_config, &team_name);
     validate_result(&team)
+}
+
+fn team_names_for_files(file_paths: Vec<String>) -> Result<Value, Error> {
+    let run_config = build_run_config();
+    let path_teams = runner::teams_for_files_from_codeowners(&run_config, &file_paths);
+    match path_teams {
+        Ok(path_teams) => {
+            let mut teams_map: HashMap<String, Option<Team>> = HashMap::new();
+            for (path, team) in path_teams {
+                if let Some(found_team) = team {
+                    teams_map.insert(path, Some(Team {
+                        team_name: found_team.name.to_string(),
+                        team_config_yml: found_team.name.to_string(),
+                        reasons: vec![],
+                    }));
+                } else {
+                    teams_map.insert(path, None);
+                }
+            }
+            let serialized: Value = serialize(&teams_map)?;
+            Ok(serialized)
+        }
+        Err(e) => Err(Error::new(magnus::exception::runtime_error(), e.to_string())),
+    }
 }
 
 fn for_file(file_path: String) -> Result<Option<Value>, Error> {
@@ -102,6 +126,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     module.define_singleton_method("validate", function!(validate, 0))?;
     module.define_singleton_method("for_team", function!(for_team, 1))?;
     module.define_singleton_method("version", function!(version, 0))?;
+    module.define_singleton_method("team_names_for_files", function!(team_names_for_files, 1))?;
 
     Ok(())
 }

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -34,12 +34,37 @@ module CodeOwnership
   requires_ancestor { Kernel }
   GlobsToOwningTeamMap = T.type_alias { T::Hash[String, CodeTeams::Team] }
 
+  # Returns the version of the code_ownership gem and the codeowners-rs gem.
   sig { returns(T::Array[String]) }
   def version
     ["code_ownership version: #{VERSION}",
      "codeowners-rs version: #{::RustCodeOwners.version}"]
   end
 
+  # Returns the owning team for a given file path.
+  #
+  # @param file [String] The path to the file to find ownership for. Can be relative or absolute.
+  # @param from_codeowners [Boolean] (default: true) When true, uses CODEOWNERS file to determine ownership.
+  #                                  When false, uses alternative team finding strategies (e.g., package ownership).
+  #                                  from_codeowners true is faster because it simply matches the provided file to the generate CODEOWNERS file. This is a safe option when you can trust the CODEOWNERS file to be up to date.
+  # @param allow_raise [Boolean] (default: false) When true, raises an exception if ownership cannot be determined.
+  #                              When false, returns nil for files without ownership.
+  #
+  # @return [CodeTeams::Team, nil] The team that owns the file, or nil if no owner is found
+  #                                 (unless allow_raise is true, in which case an exception is raised).
+  #
+  # @example Find owner for a file using CODEOWNERS
+  #   team = CodeOwnership.for_file('app/models/user.rb')
+  #   # => #<CodeTeams::Team:0x... @name="platform">
+  #
+  # @example Find owner without using CODEOWNERS
+  #   team = CodeOwnership.for_file('app/models/user.rb', from_codeowners: false)
+  #   # => #<CodeTeams::Team:0x... @name="platform">
+  #
+  # @example Raise if no owner is found
+  #   team = CodeOwnership.for_file('unknown_file.rb', allow_raise: true)
+  #   # => raises exception if no owner found
+  #
   sig { params(file: String, from_codeowners: T::Boolean, allow_raise: T::Boolean).returns(T.nilable(CodeTeams::Team)) }
   def for_file(file, from_codeowners: true, allow_raise: false)
     if from_codeowners
@@ -49,11 +74,92 @@ module CodeOwnership
     end
   end
 
+  # Returns the owning teams for multiple file paths using the CODEOWNERS file.
+  #
+  # This method efficiently determines ownership for multiple files in a single operation
+  # by leveraging the generated CODEOWNERS file. It's more performant than calling
+  # `for_file` multiple times when you need to check ownership for many files.
+  #
+  # @param files [Array<String>] An array of file paths to find ownership for.
+  #                               Paths can be relative to the project root or absolute.
+  # @param allow_raise [Boolean] (default: false) When true, raises an exception if a team
+  #                              name in CODEOWNERS cannot be resolved to an actual team.
+  #                              When false, returns nil for files with unresolvable teams.
+  #
+  # @return [T::Hash[String, T.nilable(CodeTeams::Team)]] A hash mapping each file path to its
+  #                                                 owning team. Files without ownership
+  #                                                 or with unresolvable teams will map to nil.
+  #
+  # @example Get owners for multiple files
+  #   files = ['app/models/user.rb', 'app/controllers/users_controller.rb', 'config/routes.rb']
+  #   owners = CodeOwnership.teams_for_files_from_codeowners(files)
+  #   # => {
+  #   #   'app/models/user.rb' => #<CodeTeams::Team:0x... @name="platform">,
+  #   #   'app/controllers/users_controller.rb' => #<CodeTeams::Team:0x... @name="platform">,
+  #   #   'config/routes.rb' => #<CodeTeams::Team:0x... @name="infrastructure">
+  #   # }
+  #
+  # @example Handle files without owners
+  #   files = ['owned_file.rb', 'unowned_file.txt']
+  #   owners = CodeOwnership.teams_for_files_from_codeowners(files)
+  #   # => {
+  #   #   'owned_file.rb' => #<CodeTeams::Team:0x... @name="backend">,
+  #   #   'unowned_file.txt' => nil
+  #   # }
+  #
+  # @note This method uses caching internally for performance. The cache is populated
+  #       as files are processed and reused for subsequent lookups.
+  #
+  # @note This method relies on the CODEOWNERS file being up-to-date. Run
+  #       `CodeOwnership.validate!` to ensure the CODEOWNERS file is current.
+  #
+  # @see #for_file for single file ownership lookup
+  # @see #validate! for ensuring CODEOWNERS file is up-to-date
+  #
   sig { params(files: T::Array[String], allow_raise: T::Boolean).returns(T::Hash[String, T.nilable(CodeTeams::Team)]) }
   def teams_for_files_from_codeowners(files, allow_raise: false)
     Private::TeamFinder.teams_for_files(files, allow_raise: allow_raise)
   end
 
+  # Returns detailed ownership information for a given file path.
+  #
+  # This method provides verbose ownership details including the team name,
+  # team configuration file path, and the reasons/sources for ownership assignment.
+  # It's particularly useful for debugging ownership assignments and understanding
+  # why a file is owned by a specific team.
+  #
+  # @param file [String] The path to the file to find ownership for. Can be relative or absolute.
+  #
+  # @return [T::Hash[Symbol, String], nil] A hash containing detailed ownership information,
+  #                                         or nil if no owner is found.
+  #
+  # The returned hash contains the following keys when an owner is found:
+  # - :team_name [String] - The name of the owning team
+  # - :team_config_yml [String] - Path to the team's configuration YAML file
+  # - :reasons [Array<String>] - List of reasons/sources explaining why this team owns the file
+  #                               (e.g., "CODEOWNERS pattern: /app/models/**", "Package ownership")
+  #
+  # @example Get verbose ownership details
+  #   details = CodeOwnership.for_file_verbose('app/models/user.rb')
+  #   # => {
+  #   #   team_name: "platform",
+  #   #   team_config_yml: "config/teams/platform.yml",
+  #   #   reasons: ["Matched pattern '/app/models/**' in CODEOWNERS"]
+  #   # }
+  #
+  # @example Handle unowned files
+  #   details = CodeOwnership.for_file_verbose('unowned_file.txt')
+  #   # => nil
+  #
+  # @note This method is primarily used by the CLI tool when the --verbose flag is provided,
+  #       allowing users to understand the ownership assignment logic.
+  #
+  # @note Unlike `for_file`, this method always uses the CODEOWNERS file and other ownership
+  #       sources to determine ownership, providing complete context about the ownership decision.
+  #
+  # @see #for_file for a simpler ownership lookup that returns just the team
+  # @see CLI#for_file for the command-line interface that uses this method
+  #
   sig { params(file: String).returns(T.nilable(T::Hash[Symbol, String])) }
   def for_file_verbose(file)
     ::RustCodeOwners.for_file(file)
@@ -65,6 +171,55 @@ module CodeOwnership
     ::RustCodeOwners.for_team(team.name)
   end
 
+  # Validates code ownership configuration and optionally corrects issues.
+  #
+  # This method performs comprehensive validation of the code ownership setup, ensuring:
+  # 1. Only one ownership mechanism is defined per file (no conflicts between annotations, packages, or globs)
+  # 2. All referenced teams are valid (exist in CodeTeams configuration)
+  # 3. All files have ownership (unless explicitly listed in unowned_globs)
+  # 4. The .github/CODEOWNERS file is up-to-date and properly formatted
+  #
+  # When autocorrect is enabled, the method will automatically:
+  # - Generate or update the CODEOWNERS file based on current ownership rules
+  # - Fix any formatting issues in the CODEOWNERS file
+  # - Stage the corrected CODEOWNERS file (unless stage_changes is false)
+  #
+  # @param autocorrect [Boolean] Whether to automatically fix correctable issues (default: true)
+  #                              When true, regenerates and updates the CODEOWNERS file
+  #                              When false, only validates without making changes
+  #
+  # @param stage_changes [Boolean] Whether to stage the CODEOWNERS file after autocorrection (default: true)
+  #                                Only applies when autocorrect is true
+  #                                When false, changes are written but not staged with git
+  #
+  # @param files [Array<String>, nil] Ignored. This is a legacy parameter that is no longer used.
+  #
+  # @return [void]
+  #
+  # @raise [RuntimeError] Raises an error if validation fails with details about:
+  #                       - Files with conflicting ownership definitions
+  #                       - References to non-existent teams
+  #                       - Files without ownership (not in unowned_globs)
+  #                       - CODEOWNERS file inconsistencies
+  #
+  # @example Basic validation with autocorrection
+  #   CodeOwnership.validate!
+  #   # Validates all files and auto-corrects/stages CODEOWNERS if needed
+  #
+  # @example Validation without making changes
+  #   CodeOwnership.validate!(autocorrect: false)
+  #   # Only checks for issues without updating CODEOWNERS
+  #
+  # @example Validate and fix but don't stage changes
+  #   CodeOwnership.validate!(autocorrect: true, stage_changes: false)
+  #   # Fixes CODEOWNERS but doesn't stage it with git
+  #
+  # @note This method is called by the CLI command: bin/codeownership validate
+  # @note The validation can be disabled for CODEOWNERS by setting skip_codeowners_validation: true in config/code_ownership.yml
+  #
+  # @see CLI.validate! for the command-line interface
+  # @see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners for CODEOWNERS format
+  #
   sig do
     params(
       autocorrect: T::Boolean,

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -45,6 +45,13 @@ module CodeOwnership
     Private::TeamFinder.for_file(file)
   end
 
+  sig { params(files: T::Array[String]).returns(T::Hash[String, T.nilable(CodeTeams::Team)]) }
+  def team_names_for_files(files)
+    ::RustCodeOwners.team_names_for_files(files).transform_values do |team|
+      team ? CodeTeams.find(team[:team_name]) : nil
+    end
+  end
+
   sig { params(file: String).returns(T.nilable(T::Hash[Symbol, String])) }
   def for_file_verbose(file)
     ::RustCodeOwners.for_file(file)
@@ -54,9 +61,6 @@ module CodeOwnership
   def for_team(team)
     team = T.must(CodeTeams.find(team)) if team.is_a?(String)
     ::RustCodeOwners.for_team(team.name)
-  end
-
-  class InvalidCodeOwnershipConfigurationError < StandardError
   end
 
   sig do

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -40,13 +40,25 @@ module CodeOwnership
      "codeowners-rs version: #{::RustCodeOwners.version}"]
   end
 
+  # Returns the team that owns the given file based on the CODEOWNERS file.
+  # This is much faster and can be safely used when the CODEOWNERS files is up to date.
+  # Examples of reliable usage:
+  # - running in CI pipeline
+  # - running on the server
+  # Examples of unreliable usage:
+  # - running in IDE when files are changing and the CODEOWNERS file is not getting updated
+  sig { params(file: String).returns(T.nilable(CodeTeams::Team)) }
+  def for_file_from_codeowners(file)
+    teams_for_files_from_codeowners([file]).values.first
+  end
+
   sig { params(file: String).returns(T.nilable(CodeTeams::Team)) }
   def for_file(file)
     Private::TeamFinder.for_file(file)
   end
 
   sig { params(files: T::Array[String]).returns(T::Hash[String, T.nilable(CodeTeams::Team)]) }
-  def teams_for_files(files)
+  def teams_for_files_from_codeowners(files)
     Private::TeamFinder.teams_for_files(files)
   end
 

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -40,26 +40,18 @@ module CodeOwnership
      "codeowners-rs version: #{::RustCodeOwners.version}"]
   end
 
-  # Returns the team that owns the given file based on the CODEOWNERS file.
-  # This is much faster and can be safely used when the CODEOWNERS files is up to date.
-  # Examples of reliable usage:
-  # - running in CI pipeline
-  # - running on the server
-  # Examples of unreliable usage:
-  # - running in IDE when files are changing and the CODEOWNERS file is not getting updated
-  sig { params(file: String).returns(T.nilable(CodeTeams::Team)) }
-  def for_file_from_codeowners(file)
-    teams_for_files_from_codeowners([file]).values.first
+  sig { params(file: String, from_codeowners: T::Boolean, allow_raise: T::Boolean).returns(T.nilable(CodeTeams::Team)) }
+  def for_file(file, from_codeowners: true, allow_raise: false)
+    if from_codeowners
+      teams_for_files_from_codeowners([file], allow_raise: allow_raise).values.first
+    else
+      Private::TeamFinder.for_file(file, allow_raise: allow_raise)
+    end
   end
 
-  sig { params(file: String).returns(T.nilable(CodeTeams::Team)) }
-  def for_file(file)
-    Private::TeamFinder.for_file(file)
-  end
-
-  sig { params(files: T::Array[String]).returns(T::Hash[String, T.nilable(CodeTeams::Team)]) }
-  def teams_for_files_from_codeowners(files)
-    Private::TeamFinder.teams_for_files(files)
+  sig { params(files: T::Array[String], allow_raise: T::Boolean).returns(T::Hash[String, T.nilable(CodeTeams::Team)]) }
+  def teams_for_files_from_codeowners(files, allow_raise: false)
+    Private::TeamFinder.teams_for_files(files, allow_raise: allow_raise)
   end
 
   sig { params(file: String).returns(T.nilable(T::Hash[Symbol, String])) }

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -46,10 +46,8 @@ module CodeOwnership
   end
 
   sig { params(files: T::Array[String]).returns(T::Hash[String, T.nilable(CodeTeams::Team)]) }
-  def team_names_for_files(files)
-    ::RustCodeOwners.team_names_for_files(files).transform_values do |team|
-      team ? CodeTeams.find(team[:team_name]) : nil
-    end
+  def teams_for_files(files)
+    Private::TeamFinder.teams_for_files(files)
   end
 
   sig { params(file: String).returns(T.nilable(T::Hash[Symbol, String])) }

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -111,7 +111,54 @@ module CodeOwnership
         raise "Please pass in one file. Use `#{EXECUTABLE} for_file --help` for more info"
       end
 
-      puts CodeOwnership::Private::ForFileOutputBuilder.build(file_path: files.first, json: !!options[:json], verbose: !!options[:verbose])
+      if options[:verbose]
+        for_file_verbose(file: files.first, json: options[:json])
+      else
+        for_file_terse(file: files.first, json: options[:json])
+      end
+    end
+
+    def self.for_file_terse(file:, json:)
+      team = CodeOwnership.for_file(file)
+
+      team_name = team&.name || 'Unowned'
+      team_yml = team&.config_yml || 'Unowned'
+
+      if json
+        json_output = {
+          team_name: team_name,
+          team_yml: team_yml
+        }
+
+        puts json_output.to_json
+      else
+        puts <<~MSG
+          Team: #{team_name}
+          Team YML: #{team_yml}
+        MSG
+      end
+    end
+
+    def self.for_file_verbose(file:, json:)
+      verbose = CodeOwnership.for_file_verbose(file) || {team_name: 'Unowned', team_config_yml: 'Unowned', reasons: []}
+
+      if json
+        json = {
+          team_name: verbose[:team_name],
+          team_yml: verbose[:team_config_yml],
+          reasons: verbose[:reasons]
+        }
+
+        puts json.to_json
+      else
+        messages = ["Team: #{verbose[:team_name]}", "Team YML: #{verbose[:team_config_yml]}"]
+        if verbose[:reasons].any?
+          messages << "Reasons:\n- #{verbose[:reasons].join("\n-")}"
+        end
+        messages.last << "\n"
+
+        puts messages.join("\n")
+      end
     end
 
     def self.for_team(argv)

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -111,54 +111,7 @@ module CodeOwnership
         raise "Please pass in one file. Use `#{EXECUTABLE} for_file --help` for more info"
       end
 
-      if options[:verbose]
-        for_file_verbose(file: files.first, json: options[:json])
-      else
-        for_file_terse(file: files.first, json: options[:json])
-      end
-    end
-
-    def self.for_file_terse(file:, json:)
-      team = CodeOwnership.for_file(file)
-
-      team_name = team&.name || 'Unowned'
-      team_yml = team&.config_yml || 'Unowned'
-
-      if json
-        json_output = {
-          team_name: team_name,
-          team_yml: team_yml
-        }
-
-        puts json_output.to_json
-      else
-        puts <<~MSG
-          Team: #{team_name}
-          Team YML: #{team_yml}
-        MSG
-      end
-    end
-
-    def self.for_file_verbose(file:, json:)
-      verbose = CodeOwnership.for_file_verbose(file) || {team_name: 'Unowned', team_config_yml: 'Unowned', reasons: []}
-
-      if json
-        json = {
-          team_name: verbose[:team_name],
-          team_yml: verbose[:team_config_yml],
-          reasons: verbose[:reasons]
-        }
-
-        puts json.to_json
-      else
-        messages = ["Team: #{verbose[:team_name]}", "Team YML: #{verbose[:team_config_yml]}"]
-        if verbose[:reasons].any?
-          messages << "Reasons:\n- #{verbose[:reasons].join("\n-")}"
-        end
-        messages.last << "\n"
-
-        puts messages.join("\n")
-      end
+      puts CodeOwnership::Private::ForFileOutputBuilder.build(file_path: files.first, json: !!options[:json], verbose: !!options[:verbose])
     end
 
     def self.for_team(argv)

--- a/lib/code_ownership/private/for_file_output_builder.rb
+++ b/lib/code_ownership/private/for_file_output_builder.rb
@@ -53,7 +53,7 @@ module CodeOwnership
 
       sig { returns(T::Hash[Symbol, T.untyped]) }
       def build_terse
-        team = CodeOwnership.for_file(@file_path)
+        team = CodeOwnership.for_file(@file_path, from_codeowners: false, allow_raise: true)
 
         if team.nil?
           UNOWNED_OUTPUT

--- a/lib/code_ownership/private/team_finder.rb
+++ b/lib/code_ownership/private/team_finder.rb
@@ -30,6 +30,16 @@ module CodeOwnership
         FilePathTeamCache.get(file_path)
       end
 
+      sig { params(files: T::Array[String]).returns(T::Hash[String, T.nilable(CodeTeams::Team)]) }
+      def teams_for_files(files)
+        ::RustCodeOwners.teams_for_files(files).each_with_object({}) do |path_team, hash|
+          file_path, team = path_team
+          found_team = team ? CodeTeams.find(team[:team_name]) : nil
+          FilePathTeamCache.set(file_path, found_team)
+          hash[file_path] = found_team
+        end
+      end
+
       sig { params(klass: T.nilable(T.any(T::Class[T.anything], Module))).returns(T.nilable(::CodeTeams::Team)) }
       def for_class(klass)
         file_path = FilePathFinder.path_from_klass(klass)

--- a/lib/code_ownership/version.rb
+++ b/lib/code_ownership/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CodeOwnership
-  VERSION = '2.0.0-2'
+  VERSION = '2.0.0-3'
 end

--- a/sorbet/rbi/manual.rbi
+++ b/sorbet/rbi/manual.rbi
@@ -18,5 +18,8 @@ module RustCodeOwners
 
     def version
     end
+
+    def team_names_for_files(files)
+    end
   end
 end

--- a/sorbet/rbi/manual.rbi
+++ b/sorbet/rbi/manual.rbi
@@ -19,7 +19,7 @@ module RustCodeOwners
     def version
     end
 
-    def team_names_for_files(files)
+    def teams_for_files(files)
     end
   end
 end

--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe CodeOwnership::Cli do
           expect(CodeOwnership::Cli).to receive(:puts).with(<<~MSG)
             Team: My Team
             Team YML: config/teams/my_team.yml
-            Description:
+            Reasons:
             - Owner specified in Team YML as an owned_glob `app/**/*.rb`
           MSG
           subject
@@ -220,17 +220,17 @@ RSpec.describe CodeOwnership::Cli do
           subject
         end
 
-        context 'when run with --verbose' do
+        context 'when run with multiple files' do
           let(:argv) { ['for_file', '--json', '--verbose', 'app/services/my_file.rb'] }
           it 'outputs JSONified information to the console' do
             json = {
               team_name: 'My Team',
               team_yml: 'config/teams/my_team.yml',
-              description: ['Owner specified in Team YML as an owned_glob `app/**/*.rb`']
+              reasons: ['Owner specified in Team YML as an owned_glob `app/**/*.rb`']
             }
             expect(CodeOwnership::Cli).to receive(:puts).with(json.to_json)
             subject
-          end
+          end  
         end
       end
 

--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe CodeOwnership::Cli do
           expect(CodeOwnership::Cli).to receive(:puts).with(<<~MSG)
             Team: My Team
             Team YML: config/teams/my_team.yml
-            Reasons:
+            Description:
             - Owner specified in Team YML as an owned_glob `app/**/*.rb`
           MSG
           subject
@@ -220,17 +220,17 @@ RSpec.describe CodeOwnership::Cli do
           subject
         end
 
-        context 'when run with multiple files' do
+        context 'when run with --verbose' do
           let(:argv) { ['for_file', '--json', '--verbose', 'app/services/my_file.rb'] }
           it 'outputs JSONified information to the console' do
             json = {
               team_name: 'My Team',
               team_yml: 'config/teams/my_team.yml',
-              reasons: ['Owner specified in Team YML as an owned_glob `app/**/*.rb`']
+              description: ['Owner specified in Team YML as an owned_glob `app/**/*.rb`']
             }
             expect(CodeOwnership::Cli).to receive(:puts).with(json.to_json)
             subject
-          end  
+          end
         end
       end
 


### PR DESCRIPTION
This pull request introduces several improvements and new features to the code ownership infrastructure, focusing on performance, usability, and maintainability. The most significant changes include a new bulk ownership lookup API for files, enhanced documentation and parameterization for ownership queries, workflow optimizations for CI/CD, and dependency updates for the Rust backend. These changes make ownership queries faster and more flexible, improve the artifact publishing and release process, and add more robust validation and error handling.

**Features & API Improvements**
* Added bulk ownership lookup: Implemented `teams_for_files` in the Rust extension and exposed `teams_for_files_from_codeowners` in Ruby, allowing efficient ownership queries for multiple files at once. This is significantly faster than querying files individually. [[1]](diffhunk://#diff-0f51c69eec93c29b5726692108f1a8dadbb8cdff2ac7b4544acc7a13acc57e6cR21-R44) [[2]](diffhunk://#diff-0f51c69eec93c29b5726692108f1a8dadbb8cdff2ac7b4544acc7a13acc57e6cR129) [[3]](diffhunk://#diff-6c8ae83c8c39eb48ba063883f1a4b2b8882b271837dda6571d843aa62644e097R37-R162)
* Enhanced `for_file` API: Added `from_codeowners` and `allow_raise` parameters to `for_file`, enabling users to choose lookup strategy and error handling behavior. Documentation was expanded with examples and usage notes. [[1]](diffhunk://#diff-6c8ae83c8c39eb48ba063883f1a4b2b8882b271837dda6571d843aa62644e097R37-R162) [[2]](diffhunk://#diff-6d12b724abbe021a63dead1176e8419a977f73708018fb09f221d1821ecd564cL15-R16)
* Improved verbose ownership reporting: The CLI and API now provide detailed ownership reasons for files, and internal code uses stricter error handling for missing ownership. [[1]](diffhunk://#diff-6c8ae83c8c39eb48ba063883f1a4b2b8882b271837dda6571d843aa62644e097R37-R162) [[2]](diffhunk://#diff-370727d96ffa7416253092f89b7a82a9f37005268e85ad29cdd8f53e784ce9daL56-R56)

**CI/CD & Workflow Optimizations**
* Refactored CD workflow: Switched to `workflow_call` trigger, improved artifact retention, cache isolation, and added platform-specific gem smoke tests. The release step now generates detailed notes and only publishes new versions. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L5-R5) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R52-R92) [[3]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L90-R184)
* Updated platform exclusions: Added more unsupported platforms to the build matrix for clarity and reliability.
* Improved CI matrix: Added explicit Rust toolchain selection and disabled cargo cache for more predictable builds.

**Dependency Updates**
* Updated `codeowners-rs` dependency: Upgraded to version `v0.2.17` for bug fixes and new features.

**Documentation & Validation**
* Expanded documentation: All public methods now have thorough documentation, usage examples, and notes on performance and error handling. [[1]](diffhunk://#diff-6c8ae83c8c39eb48ba063883f1a4b2b8882b271837dda6571d843aa62644e097R37-R162) [[2]](diffhunk://#diff-6c8ae83c8c39eb48ba063883f1a4b2b8882b271837dda6571d843aa62644e097L59-R222)
* Improved validation: The validation API is now more robust, with autocorrect and staging options, and clearer error reporting for misconfigurations.

**References:** [[1]](diffhunk://#diff-0f51c69eec93c29b5726692108f1a8dadbb8cdff2ac7b4544acc7a13acc57e6cR21-R44) [[2]](diffhunk://#diff-0f51c69eec93c29b5726692108f1a8dadbb8cdff2ac7b4544acc7a13acc57e6cR129) [[3]](diffhunk://#diff-6c8ae83c8c39eb48ba063883f1a4b2b8882b271837dda6571d843aa62644e097R37-R162) [[4]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L5-R5) [[5]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R52-R92)Incorporates https://github.com/rubyatscale/codeowners-rs/releases/tag/v0.2.15 for finding teams from an array of files.

This is an optimization for when callers have a large number of files for which they need to know the owning teams.