### PR TITLE
Allow manual CD triggering

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,7 @@
   
   on:
     workflow_call:
+    workflow_dispatch:
   
   concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow configuration. The change adds support for manually triggering the continuous deployment workflow.

* Added the `workflow_dispatch` event to `.github/workflows/cd.yml`, enabling manual workflow runs.