### PR TITLE
Release 2.0.0, changing the gem to a rust library wrapper

### DIFF
--- a/lib/code_ownership/version.rb
+++ b/lib/code_ownership/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module CodeOwnership
-  VERSION = '2.0.0-5'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
Code owner generate and validate is significantly faster, from more than 20 seconds to less than 10 seconds on our monolith, sometime as low as 3 seconds.