### PR TITLE
Fix regression in package.yml metadata.owner key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 [[package]]
 name = "codeowners"
 version = "0.3.1"
-source = "git+https://github.com/rubyatscale/codeowners-rs.git?branch=main#c8a5d535a9ccb286b8a2274ff98bd52c058908e4"
+source = "git+https://github.com/rubyatscale/codeowners-rs.git?branch=push-qoonoyqpvuwm#88dd208c320e7445616eca57232e5e3a5738b2eb"
 dependencies = [
  "clap",
  "clap_derive",

--- a/ext/code_ownership/Cargo.toml
+++ b/ext/code_ownership/Cargo.toml
@@ -10,21 +10,21 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rb-sys = { version = "0.9.111", features = [
-    "bindgen-rbimpls",
-    "bindgen-deprecated-types",
-    "stable-api-compiled-fallback",
+  "bindgen-rbimpls",
+  "bindgen-deprecated-types",
+  "stable-api-compiled-fallback",
 ] }
 magnus = { version = "0.8" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_magnus = "0.10"
-codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", branch = "main" }
+codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", branch = "push-qoonoyqpvuwm" }
 
 [dev-dependencies]
 rb-sys = { version = "0.9.117", features = [
-    "link-ruby",
-    "bindgen-rbimpls",
-    "bindgen-deprecated-types",
-    "stable-api-compiled-fallback",
+  "link-ruby",
+  "bindgen-rbimpls",
+  "bindgen-deprecated-types",
+  "stable-api-compiled-fallback",
 ] }
 
 [build-dependencies]

--- a/spec/lib/code_ownership_spec.rb
+++ b/spec/lib/code_ownership_spec.rb
@@ -195,6 +195,23 @@ RSpec.describe CodeOwnership do
         end
       end
 
+      context 'when ownership is found via metadata.owner in package.yml' do
+        let(:file_path) { 'packs/metadata_owner_pack/some_file.rb' }
+
+        before do
+          write_file('packs/metadata_owner_pack/package.yml', <<~CONTENTS)
+            metadata:
+              owner: Foo
+          CONTENTS
+          write_file(file_path, '# some content')
+          RustCodeOwners.generate_and_validate(nil, false)
+        end
+
+        it 'returns the correct team' do
+          expect(subject).to eq CodeTeams.find('Foo')
+        end
+      end
+
       context 'when ownership is found but team is not found' do
         let(:file_path) { 'packs/my_pack/owned_file.rb' }
         before do


### PR DESCRIPTION
As far as I can tell, this key was not intentionally removed and its presence is missed. Based on issues reported, we're restoring support rather than fix all the other things that depend on it.

Related to: rubyatscale/code_ownership#141