### PR TITLE
Remove use of module_function

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,6 +88,10 @@ Style/Documentation:
 Style/EmptyElse:
   Enabled: false
 
+# This interacts poorly with typed code
+Style/ModuleFunction:
+  EnforcedStyle: forbidden
+
 # Sometimes we want to more explicitly list out a condition
 Style/RedundantCondition:
   Enabled: false

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'code_teams', '~> 1.0'
   spec.add_dependency 'packs-specification'
-  spec.add_dependency 'sorbet-runtime', '>= 0.5.11249'
+  spec.add_dependency 'sorbet-runtime', '>= 0.6.12763'
 
   spec.add_development_dependency 'debug'
   spec.add_development_dependency 'packwerk'

--- a/lib/code_ownership.rb
+++ b/lib/code_ownership.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # typed: strict
 
 require 'code_teams'
@@ -25,17 +24,13 @@ if defined?(Packwerk)
 end
 
 module CodeOwnership
-  module_function
-
   extend T::Sig
-  extend T::Helpers
 
-  requires_ancestor { Kernel }
   GlobsToOwningTeamMap = T.type_alias { T::Hash[String, CodeTeams::Team] }
 
   # Returns the version of the code_ownership gem and the codeowners-rs gem.
   sig { returns(T::Array[String]) }
-  def version
+  def self.version
     ["code_ownership version: #{VERSION}",
      "codeowners-rs version: #{::RustCodeOwners.version}"]
   end
@@ -65,7 +60,7 @@ module CodeOwnership
   #   # => raises exception if no owner found
   #
   sig { params(file: String, from_codeowners: T::Boolean, allow_raise: T::Boolean).returns(T.nilable(CodeTeams::Team)) }
-  def for_file(file, from_codeowners: true, allow_raise: false)
+  def self.for_file(file, from_codeowners: true, allow_raise: false)
     if from_codeowners
       teams_for_files_from_codeowners([file], allow_raise: allow_raise).values.first
     else
@@ -116,7 +111,7 @@ module CodeOwnership
   # @see #validate! for ensuring CODEOWNERS file is up-to-date
   #
   sig { params(files: T::Array[String], allow_raise: T::Boolean).returns(T::Hash[String, T.nilable(CodeTeams::Team)]) }
-  def teams_for_files_from_codeowners(files, allow_raise: false)
+  def self.teams_for_files_from_codeowners(files, allow_raise: false)
     Private::TeamFinder.teams_for_files(files, allow_raise: allow_raise)
   end
 
@@ -160,12 +155,12 @@ module CodeOwnership
   # @see CLI#for_file for the command-line interface that uses this method
   #
   sig { params(file: String).returns(T.nilable(T::Hash[Symbol, String])) }
-  def for_file_verbose(file)
+  def self.for_file_verbose(file)
     ::RustCodeOwners.for_file(file)
   end
 
   sig { params(team: T.any(CodeTeams::Team, String)).returns(T::Array[String]) }
-  def for_team(team)
+  def self.for_team(team)
     team = T.must(CodeTeams.find(team)) if team.is_a?(String)
     ::RustCodeOwners.for_team(team.name)
   end
@@ -226,7 +221,7 @@ module CodeOwnership
       files: T.nilable(T::Array[String])
     ).void
   end
-  def validate!(
+  def self.validate!(
     autocorrect: true,
     stage_changes: true,
     files: nil
@@ -269,7 +264,7 @@ module CodeOwnership
   # @note Leading newlines after the annotation are also removed to maintain clean formatting.
   #
   sig { params(filename: String).void }
-  def remove_file_annotation!(filename)
+  def self.remove_file_annotation!(filename)
     filepath = Pathname.new(filename)
 
     begin
@@ -292,24 +287,24 @@ module CodeOwnership
   # Given a backtrace from either `Exception#backtrace` or `caller`, find the
   # first line that corresponds to a file with assigned ownership
   sig { params(backtrace: T.nilable(T::Array[String]), excluded_teams: T::Array[::CodeTeams::Team]).returns(T.nilable(::CodeTeams::Team)) }
-  def for_backtrace(backtrace, excluded_teams: [])
+  def self.for_backtrace(backtrace, excluded_teams: [])
     Private::TeamFinder.for_backtrace(backtrace, excluded_teams: excluded_teams)
   end
 
   # Given a backtrace from either `Exception#backtrace` or `caller`, find the
   # first owned file in it, useful for figuring out which file is being blamed.
   sig { params(backtrace: T.nilable(T::Array[String]), excluded_teams: T::Array[::CodeTeams::Team]).returns(T.nilable([::CodeTeams::Team, String])) }
-  def first_owned_file_for_backtrace(backtrace, excluded_teams: [])
+  def self.first_owned_file_for_backtrace(backtrace, excluded_teams: [])
     Private::TeamFinder.first_owned_file_for_backtrace(backtrace, excluded_teams: excluded_teams)
   end
 
-  sig { params(klass: T.nilable(T.any(T::Class[T.anything], Module))).returns(T.nilable(::CodeTeams::Team)) }
-  def for_class(klass)
+  sig { params(klass: T.nilable(T.any(T::Class[T.anything], T::Module[T.anything]))).returns(T.nilable(::CodeTeams::Team)) }
+  def self.for_class(klass)
     Private::TeamFinder.for_class(klass)
   end
 
   sig { params(package: Packs::Pack).returns(T.nilable(::CodeTeams::Team)) }
-  def for_package(package)
+  def self.for_package(package)
     Private::TeamFinder.for_package(package)
   end
 

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -1,4 +1,5 @@
 # typed: true
+# frozen_string_literal: true
 
 require 'optparse'
 require 'pathname'

--- a/lib/code_ownership/private/file_path_finder.rb
+++ b/lib/code_ownership/private/file_path_finder.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
-
 # typed: strict
 
 module CodeOwnership
   module Private
     module FilePathFinder
-      module_function
-
       extend T::Sig
-      extend T::Helpers
 
       # Returns a string version of the relative path to a Rails constant,
       # or nil if it can't find anything
-      sig { params(klass: T.nilable(T.any(T::Class[T.anything], Module))).returns(T.nilable(String)) }
-      def path_from_klass(klass)
+      sig { params(klass: T.nilable(T.any(T::Class[T.anything], T::Module[T.anything]))).returns(T.nilable(String)) }
+      def self.path_from_klass(klass)
         if klass
           path = Object.const_source_location(klass.to_s)&.first
           (path && Pathname.new(path).relative_path_from(Pathname.pwd).to_s) || nil
@@ -23,7 +19,7 @@ module CodeOwnership
       end
 
       sig { params(backtrace: T.nilable(T::Array[String])).returns(T::Enumerable[String]) }
-      def from_backtrace(backtrace)
+      def self.from_backtrace(backtrace)
         return [] unless backtrace
 
         # The pattern for a backtrace hasn't changed in forever and is considered

--- a/lib/code_ownership/private/file_path_team_cache.rb
+++ b/lib/code_ownership/private/file_path_team_cache.rb
@@ -1,37 +1,33 @@
 # frozen_string_literal: true
-
 # typed: strict
 
 module CodeOwnership
   module Private
     module FilePathTeamCache
-      module_function
-
       extend T::Sig
-      extend T::Helpers
 
       sig { params(file_path: String).returns(T.nilable(CodeTeams::Team)) }
-      def get(file_path)
+      def self.get(file_path)
         cache[file_path]
       end
 
       sig { params(file_path: String, team: T.nilable(CodeTeams::Team)).void }
-      def set(file_path, team)
+      def self.set(file_path, team)
         cache[file_path] = team
       end
 
       sig { params(file_path: String).returns(T::Boolean) }
-      def cached?(file_path)
+      def self.cached?(file_path)
         cache.key?(file_path)
       end
 
       sig { void }
-      def bust_cache!
+      def self.bust_cache!
         @cache = nil
       end
 
       sig { returns(T::Hash[String, T.nilable(CodeTeams::Team)]) }
-      def cache
+      def self.cache
         @cache ||= T.let(@cache,
           T.nilable(T::Hash[String, T.nilable(CodeTeams::Team)]))
         @cache ||= {}

--- a/lib/code_ownership/private/for_file_output_builder.rb
+++ b/lib/code_ownership/private/for_file_output_builder.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # typed: strict
 
 module CodeOwnership

--- a/lib/code_ownership/version.rb
+++ b/lib/code_ownership/version.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 module CodeOwnership

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,5 +1,3 @@
---dir
-.
+--dir=.
 --ignore=/spec
 --ignore=/vendor/bundle
---enable-experimental-requires-ancestor

--- a/spec/lib/code_ownership/private/file_path_team_cache_spec.rb
+++ b/spec/lib/code_ownership/private/file_path_team_cache_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe CodeOwnership::Private::FilePathTeamCache do
   let(:file_path) { 'app/javascript/[test]/test.js' }
   let(:codes_team) { instance_double(CodeTeams::Team) }
 
+  before do
+    allow(codes_team).to receive(:is_a?).with(CodeTeams::Team).and_return(true)
+  end
+
   describe '.get' do
     subject { described_class.get(file_path) }
 


### PR DESCRIPTION
sorbet-runtime does not work on `sig`s defined on module_function methods, when called as class methods: https://github.com/sorbet/sorbet/issues/8531

tapioca also fails to include type information for the class method versions when generating gem shims: https://github.com/Shopify/tapioca/issues/2000

AFAICT, the instance version of methods created with `module_function` are not used, so this PR proposes using the class definitions only. (This ofc may not be true for dependents, so this is very much a breaking change.)

There are some other light changes for compatibility, which i'll comment on below.