### PR TITLE
Update codeowners-rs to v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,8 +200,8 @@ dependencies = [
 
 [[package]]
 name = "codeowners"
-version = "0.3.1"
-source = "git+https://github.com/rubyatscale/codeowners-rs.git?branch=main#c8a5d535a9ccb286b8a2274ff98bd52c058908e4"
+version = "0.3.2"
+source = "git+https://github.com/rubyatscale/codeowners-rs.git?tag=v0.3.2#49629b131eb788916ff5e6722719513026260480"
 dependencies = [
  "clap",
  "clap_derive",

--- a/ext/code_ownership/Cargo.toml
+++ b/ext/code_ownership/Cargo.toml
@@ -17,7 +17,7 @@ rb-sys = { version = "0.9.111", features = [
 magnus = { version = "0.8" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_magnus = "0.10"
-codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", branch = "main" }
+codeowners = { git = "https://github.com/rubyatscale/codeowners-rs.git", tag = "v0.3.2" }
 
 [dev-dependencies]
 rb-sys = { version = "0.9.117", features = [

--- a/lib/code_ownership/version.rb
+++ b/lib/code_ownership/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module CodeOwnership
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end


### PR DESCRIPTION
## Summary

- Pin the `codeowners-rs` Rust dependency to the v0.3.2 release tag instead of tracking `main`, improving build reproducibility
- Picks up bug fixes: `package.yml` metadata.owner regression, `owned_globs` filtering during validation, subdirectory tracked file paths, and missing github team name error messages
- Bump gem version to 2.1.2

## Checklist

- [x] I bumped the gem version (or don't need to) 💎

🤖 Generated with [Claude Code](https://claude.com/claude-code)