### PR TITLE
Fix CD smoke test for platform gems

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,8 +72,8 @@
             # Test that it works
             ruby -e "require 'code_ownership'; puts 'Version: ' + CodeOwnership::VERSION"
             
-            # Run a simple functionality test
-            ruby -e "require 'code_ownership'; puts CodeOwnership.for_file('lib/code_ownership.rb').inspect"
+            # Run a simple functionality test that exercises the Rust native extension
+            ruby -e "require 'code_ownership'; puts CodeOwnership.version"
             
             echo "✅ Successfully tested ${{ matrix.ruby-platform }} gem"
   


### PR DESCRIPTION
## Why

The x86_64-linux smoke test in the [CD workflow](https://github.com/rubyatscale/code_ownership/blob/main/.github/workflows/cd.yml) has been failing since the most recent dispatch (run [24575979309](https://github.com/rubyatscale/code_ownership/actions/runs/24575979309)) with:

```
Can't open config file: .../config/code_ownership.yml (No such file or directory (os error 2))
  from .../code_ownership/private/team_finder.rb:43:in 'RustCodeOwners.teams_for_files'
```

The step was calling `CodeOwnership.for_file('lib/code_ownership.rb')`, which transitively requires `config/code_ownership.yml` in the process's working directory. This repo intentionally does not ship that file — it was removed in e9f29ac back in 2023.

### Why this only showed up now

#157 switched the smoke test from a non-existent method (`CodeOwnership.file_owner_team_names`) guarded with `|| true` to the real `for_file` method, and dropped the `|| true`. The pre-#157 version silently raised `NoMethodError` and exited 0, so it never actually exercised the native extension. Because the CD workflow only runs on `workflow_dispatch`/`workflow_call`, the regression didn't surface until the next real dispatch — which was this week's v2.1.2 push.

## What changed

Replace the `for_file` call with `CodeOwnership.version`. That method calls `::RustCodeOwners.version`, which:

- Loads the platform-specific `code_ownership.so` (proving the cross-compile artifact is packaged and runnable for this ruby/platform).
- Executes a Rust function and returns the `codeowners-rs` version string.
- Requires no config file.

This is the right shape for a platform-gem smoke test: we care that the native extension loads and runs on the target platform. Ownership-lookup correctness is covered by the RSpec suite.

## How to verify

After merge, dispatch the CD workflow again. The x86_64-linux build should print the `code_ownership` + `codeowners-rs` versions and exit 0 at the smoke step.

## Checklist

- ~~I bumped the gem version (or don't need to) 💎~~ — CI-only change, no gem bump.