### PR TITLE
Add aarch64-linux-musl binary gem to CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,10 +23,9 @@
               # `arm-linux`: Cranelift doesn't support 32-bit architectures
               # `x64-mingw32`: `x64-mingw-ucrt` should be used for Ruby 3.1+ (https://github.com/rake-compiler/rake-compiler-dock?tab=readme-ov-file#windows)
               # `x64-mingw-ucrt`: Rust target not available in rake-compiler-dock
-              # `aarch64-linux-musl`: Rust target not available in rake-compiler-dock
               # 3.0 is deprecated as stable ruby version according to:
               #  https://github.com/oxidize-rb/actions/blob/main/fetch-ci-data/evaluate.rb#L54
-              exclude: [arm-linux, x64-mingw32, x64-mingw-ucrt, aarch64-linux-musl]
+              exclude: [arm-linux, x64-mingw32, x64-mingw-ucrt]
             stable-ruby-versions: |
               only: ['3.2', '3.3', '3.4', '4.0']
   

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,10 +22,9 @@
               # Excluding:
               # `arm-linux`: Cranelift doesn't support 32-bit architectures
               # `x64-mingw32`: `x64-mingw-ucrt` should be used for Ruby 3.1+ (https://github.com/rake-compiler/rake-compiler-dock?tab=readme-ov-file#windows)
-              # `x64-mingw-ucrt`: Rust target not available in rake-compiler-dock
               # 3.0 is deprecated as stable ruby version according to:
               #  https://github.com/oxidize-rb/actions/blob/main/fetch-ci-data/evaluate.rb#L54
-              exclude: [arm-linux, x64-mingw32, x64-mingw-ucrt]
+              exclude: [arm-linux, x64-mingw32]
             stable-ruby-versions: |
               only: ['3.2', '3.3', '3.4', '4.0']
   


### PR DESCRIPTION
## Summary

Removes `aarch64-linux-musl` and `x64-mingw-ucrt` from the platform exclusion list in the CD workflow. Both had been excluded with the comment "Rust target not available in rake-compiler-dock", but that is now outdated:

- `aarch64-linux-musl` → Rust target `aarch64-unknown-linux-musl` — [explicitly listed as supported](https://github.com/rake-compiler/rake-compiler-dock#supported-platforms) in rake-compiler-dock and present in the [rb-sys platform matrix](https://raw.githubusercontent.com/oxidize-rb/rb-sys/main/data/derived/github-actions-matrix.json)
- `x64-mingw-ucrt` → Rust target `x86_64-pc-windows-gnu` — also present in the rb-sys platform matrix

`x64-mingw32` remains excluded since it has been superseded by `x64-mingw-ucrt` for Ruby 3.1+ and this gem targets 3.2+. `arm-linux` remains excluded because Cranelift doesn't support 32-bit architectures.

The immediate motivation for `aarch64-linux-musl` is #167: users on Alpine Linux / ARM64 can't compile from source due to a Cargo/RubyGems < 4.0.9 conflict, and pre-built binaries resolve that without requiring a Ruby version bump.

Closes #167.
