### PR TITLE
Resolve CI annotation warnings

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@
         matrix:
           ruby-platform: ${{ fromJSON(needs.ci-data.outputs.result).supported-ruby-platforms }}
       steps:
-        - uses: actions/checkout@v5
+        - uses: actions/checkout@v6.0.3
   
         - uses: ruby/setup-ruby@v1
           with:
@@ -82,7 +82,7 @@
       permissions:
         contents: write  # Required for creating releases
       steps:
-        - uses: actions/checkout@v5
+        - uses: actions/checkout@v6.0.3
   
         - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
           with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@
         matrix:
           ruby-platform: ${{ fromJSON(needs.ci-data.outputs.result).supported-ruby-platforms }}
       steps:
-        - uses: actions/checkout@v6.0.3
+        - uses: actions/checkout@v6
   
         - uses: ruby/setup-ruby@v1
           with:
@@ -82,7 +82,7 @@
       permissions:
         contents: write  # Required for creating releases
       steps:
-        - uses: actions/checkout@v6.0.3
+        - uses: actions/checkout@v6
   
         - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
           with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@
         matrix:
           ruby-platform: ${{ fromJSON(needs.ci-data.outputs.result).supported-ruby-platforms }}
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
   
         - uses: ruby/setup-ruby@v1
           with:
@@ -82,11 +82,10 @@
       permissions:
         contents: write  # Required for creating releases
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
   
         - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
           with:
-            ruby-version-file: .ruby-version
             bundler-cache: true
             cargo-cache: false
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         ruby: ${{ fromJSON(needs.ci-data.outputs.result).stable-ruby-versions }}
         rust: ["stable"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.3
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -45,7 +45,7 @@ jobs:
     name: "RSpec (ruby-version-file)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.3
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           rustup-toolchain: stable
@@ -59,7 +59,7 @@ jobs:
     name: "Type Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         ruby: ${{ fromJSON(needs.ci-data.outputs.result).stable-ruby-versions }}
         rust: ["stable"]
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -45,7 +45,7 @@ jobs:
     name: "RSpec (ruby-version-file)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           rustup-toolchain: stable
@@ -59,7 +59,7 @@ jobs:
     name: "Type Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         ruby: ${{ fromJSON(needs.ci-data.outputs.result).stable-ruby-versions }}
         rust: ["stable"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -45,10 +45,9 @@ jobs:
     name: "RSpec (ruby-version-file)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version-file: .ruby-version
           rustup-toolchain: stable
           bundler-cache: true
           cargo-cache: false
@@ -60,12 +59,11 @@ jobs:
     name: "Type Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version-file: .ruby-version
       - name: Run static type checks
         run: bundle exec srb tc
   notify_on_failure:


### PR DESCRIPTION
Resolves the annotation warnings surfaced in CI ([run 27302012478](https://github.com/rubyatscale/code_ownership/actions/runs/27302012478)).

## Warnings addressed

**1. `Unexpected input(s) 'ruby-version-file'`**

Neither `ruby/setup-ruby@v1` nor `oxidize-rb/actions/setup-ruby-and-rust@v1` accepts a `ruby-version-file` input (verified against each action's `action.yml`; the warning's valid-input list matches `ruby/setup-ruby` exactly). Both actions automatically read `.ruby-version` when `ruby-version` is unset, so the input was a no-op that only produced a warning.

Removed the three usages:
- `ci.yml` — `rspec_ruby_version_file` job (setup-ruby-and-rust)
- `ci.yml` — `static_type_check` job (ruby/setup-ruby)
- `cd.yml` — `release` job (setup-ruby-and-rust)

Behavior is unchanged: each step still resolves Ruby from `.ruby-version` via auto-detection.

**2. `Node.js 20 actions are deprecated … actions/checkout@v4`**

Bumped all 5 occurrences of `actions/checkout` to `@v6`, which runs on Node.js 24. The other actions in these workflows already run on Node.js 24.

## Testing

Both workflow files validated as parseable YAML.
