### PR TITLE
Require Ruby >= 3.3 and update CI Ruby versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,7 +26,7 @@
               #  https://github.com/oxidize-rb/actions/blob/main/fetch-ci-data/evaluate.rb#L54
               exclude: [arm-linux, x64-mingw32]
             stable-ruby-versions: |
-              only: ['3.2', '3.3', '3.4', '4.0']
+              only: ['3.3', '3.4', '4.0']
   
     build:
       name: Build native gems

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           stable-ruby-versions: |
             # Explicitly include all Ruby versions we want to support
             # to ensure binaries are built for each version
-            only: ['3.2', '3.3', '3.4', '4.0']
+            only: ['3.3', '3.4', '4.0']
   rspec:
     runs-on: ${{ matrix.os }}
     needs: ci-data

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ AllCops:
     - vendor/bundle/**/**
     - tmp/**/**
     - target/**/**
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
 
 Metrics/ParameterLists:
   Enabled: false

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
           'public gem pushes.'
   end
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 3.2', '< 4.1.dev')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.3', '< 4.1.dev')
 
   # https://guides.rubygems.org/make-your-own-gem/#adding-an-executable
   # and


### PR DESCRIPTION
## Summary

Ruby 3.2 is now EOL. This PR raises the minimum supported Ruby to **3.3** and refreshes CI so the test matrices target the supported set (**3.3** and **3.4**, plus the repo's intentional **4.0** entry).

Motivation: resolve Ruby version restrictions from rubyatscale/pack_stats#56, where supporting EOL Ruby forced older/vulnerable transitive dependencies.

## Changes

- **`code_ownership.gemspec`**: `required_ruby_version` raised from `Gem::Requirement.new('>= 3.2', '< 4.1.dev')` to `Gem::Requirement.new('>= 3.3', '< 4.1.dev')` (upper bound preserved).
- **`.github/workflows/ci.yml`**: stable-ruby-versions matrix now `['3.3', '3.4', '4.0']` (dropped `3.2`).
- **`.github/workflows/cd.yml`**: stable-ruby-versions matrix now `['3.3', '3.4', '4.0']` (dropped `3.2`); the `ruby-version: '4.0'` build pin is unchanged.
- **`.rubocop.yml`**: `TargetRubyVersion` raised from `3.2` to `3.3`.

## Notes

- `.ruby-version` (`4.0.1`) is already >= 3.3 and was left unchanged.
- The intentional `'4.0'` matrix entries were preserved.
- No `bundle install` was run and `Gemfile.lock` is unchanged.
- Latest stable Ruby is 3.4.9; 3.5 is preview-only and not included.
